### PR TITLE
Update UseAtlas.cmake

### DIFF
--- a/macros/UseAtlas.cmake
+++ b/macros/UseAtlas.cmake
@@ -106,6 +106,8 @@ IF (NOT USE_MKL)
                 /usr/lib/sse3
                 /usr/lib/
                 /usr/lib/atlas
+                /usr/lib/atlas-base
+                /usr/lib64/atlas-base
                 )
             SET(ATLAS_LIBS atlas cblas f77blas clapack lapack blas)
 


### PR DESCRIPTION
Add atlas-base as a path when searching for ATLAS_LIB. (It fixes my compilation error on Ubuntu 13.04.)
