### PR TITLE
Add a way to catch at least some matio errors.

### DIFF
--- a/OpenMEEG/libs/OpenMEEGMaths/include/Exceptions.H
+++ b/OpenMEEG/libs/OpenMEEGMaths/include/Exceptions.H
@@ -14,7 +14,7 @@ namespace OpenMEEG {
 
         typedef enum { UNEXPECTED = 128, IO_EXCPT,
                        BAD_FILE, BAD_FILE_OPEN, BAD_CONTENT, NO_SUFFIX, BAD_HDR, BAD_DATA, BAD_VECT, UNKN_DIM, BAD_SYMM_MAT,
-                       BAD_STORAGE_TYPE, NO_IO, UNKN_FILE_FMT, UNKN_FILE_SUFFIX, NO_FILE_FMT, UNKN_NAMED_FILE_FMT,
+                       BAD_STORAGE_TYPE, NO_IO, MATIO_ERROR, UNKN_FILE_FMT, UNKN_FILE_SUFFIX, NO_FILE_FMT, UNKN_NAMED_FILE_FMT,
                        IMPOSSIBLE_IDENTIFICATION } ExceptionCode;
 
 
@@ -206,6 +206,11 @@ namespace OpenMEEG {
             static std::string message(const std::string& file,const Mode& mode) {
                 return std::string("Unable to find ")+((mode==READ) ? "reader" : "writer")+" for file "+file+".";
             }
+        };
+
+        struct OPENMEEGMATHS_EXPORT MatioError: public IOException {
+            MatioError(const std::string& err): IOException(err) { }
+            ExceptionCode code() const throw() { return MATIO_ERROR; }
         };
 
         struct OPENMEEGMATHS_EXPORT UnknownFileFormat: public IOException {

--- a/OpenMEEG/libs/OpenMEEGMaths/include/MatlabIO.H
+++ b/OpenMEEG/libs/OpenMEEGMaths/include/MatlabIO.H
@@ -247,7 +247,30 @@ namespace OpenMEEG {
 
         private:
 
-            MatlabIO(): MathsIOBase(5) { }
+            static void matiologfunc(const int log_level,char* message) {
+
+                //  Ugly copy of values in matio/io.c, but those are not exported...
+
+                enum { LOG_LEVEL_ERROR=1, LOG_LEVEL_CRITICAL=2, LOG_LEVEL_WARNING=4, LOG_LEVEL_MESSAGE=8, LOG_LEVEL_DEBUG=16 };
+
+                if (log_level & (LOG_LEVEL_CRITICAL|LOG_LEVEL_ERROR))
+                    throw MatioError(message);
+
+                std::string error;
+                if (log_level==LOG_LEVEL_WARNING)
+                    error = "Warning";
+                else if (log_level==LOG_LEVEL_DEBUG)
+                    error = "Debug";
+                else if (log_level==LOG_LEVEL_MESSAGE)
+                    error = "Message";
+                else
+                    error = "Unknown error";
+
+                std::cerr << error << message << std::endl;
+            }
+
+            MatlabIO(): MathsIOBase(5) { Mat_LogInitFunc("OpenMEEG",matiologfunc); }
+
             ~MatlabIO() {};
 
             template <typename TYPE>


### PR DESCRIPTION
The title says it all. Compatible with stock matio.
Unfortunately not very easy to test. I ended up using om_matrix_info with a matlab (mat5) file in which I modified the header. Other test (with mat73 files) seem to show that Hdf5 errors are not (at least all) catched. But this is at leat an incremental improvement.

closes #65