### PR TITLE
[MRG] fix support for vecLib on Mac + restore this case on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       env:
         - USE_SYSTEM=1
         - USE_PROJECT=1
-        - BLASLAPACK_IMPLEMENTATION=OpenBLAS
+        - BLASLAPACK_IMPLEMENTATION=vecLib
     - os: osx
       compiler: clang
       env:

--- a/OpenMEEG/libs/OpenMEEGMaths/include/BlasLapackImplementations/OpenMEEGMathsvecLibConfig.h
+++ b/OpenMEEG/libs/OpenMEEGMaths/include/BlasLapackImplementations/OpenMEEGMathsvecLibConfig.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <BlasLapackImplementations/FortranCInterface.h>
+#define FC_GLOBAL(x,X) x
 
 extern "C" {
     #include <cblas.h>


### PR DESCRIPTION
choosing BLASLAPACK_IMPLEMENTATION=Auto 
uses in priority OpenBLAS (on MAC as in linux).
so the vecLib, was not tested.