### PR TITLE
[MRG] fixing the pseudo inverse test.

### DIFF
--- a/OpenMEEG/libs/OpenMEEG/src/assembleHeadMat.cpp
+++ b/OpenMEEG/libs/OpenMEEG/src/assembleHeadMat.cpp
@@ -234,7 +234,8 @@ namespace OpenMEEG {
             // ** Construct P: the null-space projector **
             Matrix W;
             {
-                Matrix U, s;
+                Matrix U;
+                SparseMatrix s;
                 mat.svd(U, s, W);
             }
 
@@ -243,7 +244,7 @@ namespace OpenMEEG {
             for ( unsigned i = Nl; i < Nc; ++i) {
                 S(i, i) = 1.0;
             }
-            P = (W * S) * W.transpose(); // P is a projector: P^2 = P and mat*P*X = 0
+            P = (W.transpose() * S) * W; // P is a projector: P^2 = P and mat*P*X = 0
             if ( filename.length() != 0 ) {
                 std::cout << "Saving projector P (" << filename << ")." << std::endl;
                 P.save(filename);

--- a/OpenMEEG/libs/OpenMEEGMaths/include/matrix.h
+++ b/OpenMEEG/libs/OpenMEEGMaths/include/matrix.h
@@ -146,7 +146,7 @@ namespace OpenMEEG {
         Matrix transpose() const;
         Matrix inverse() const;
         Matrix pinverse(double reltol=0) const;
-        void svd(Matrix &U,Matrix &S, Matrix &V, bool complete=true) const;
+        void svd(Matrix &U, SparseMatrix &S, Matrix &V, bool complete=true) const;
 
         /** \brief Get Matrix Frobenius norm
             \return norm value

--- a/OpenMEEG/libs/OpenMEEGMaths/tests/full.cpp
+++ b/OpenMEEG/libs/OpenMEEGMaths/tests/full.cpp
@@ -42,6 +42,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 #include <OpenMEEGMathsConfig.h>
 #include <matrix.h>
+#include <sparse_matrix.h>
 #include <generic_test.hpp>
 
 int main () {
@@ -108,33 +109,38 @@ int main () {
     M1(0, 0) = 1; M1(0, 4) = 2;
     M1(1, 2) = 3; M1(3, 1) = 4;
 
-    Matrix U, S, W;
+    Matrix U, W;
+    SparseMatrix S;
     M1.svd(U, S, W);
     std::cout << "SVD: M1 = U * S * W' " << std::endl;
-    std::cout << "M1 :" << std::endl;
-    M1.info();
-    std::cout << "U :" << std::endl;
-    U.info();
-    std::cout << "S :" << std::endl;
-    S.info();
-    std::cout << "W :" << std::endl;
-    W.info();
-    Matrix zero = M1 - U*S*W.transpose();
+    Matrix zero = M1 - U*S*W;
     if (zero.frobenius_norm()>eps) {
+        std::cout << "M1 :" << std::endl;
+        M1.info();
+        std::cout << "U :" << std::endl;
+        U.info();
+        std::cout << "S :" << std::endl;
+        S.info();
+        std::cout << "W :" << std::endl;
+        W.info();
         std::cerr << "Error: SVD is WRONG-1" << std::endl;
         exit(1);
     }
-    /* temporarly removing the pseudo inverse test, as casuing troubles on travis
+
     // PseudoInverse
-    M1 = Matrix(4,5);
+    M1.set(0.0);
     M1(0, 0) = 1; M1(0, 4) = 2;
     M1(1, 2) = 3; M1(3, 1) = 4;
-    zero = M1*M1.pinverse()*M1-M1;
+    Matrix M1pinv = M1.pinverse();
+    zero.set(0.);
+    zero = M1*M1pinv*M1-M1;
     if (zero.frobenius_norm()>eps) {
+        std::cout << "pinverse = M^{+} = " << std::endl;
+        M1pinv.info();
+        std::cout << "M*M^{+}*M-M = zero matrix = " << std::endl;
         zero.info();
         std::cerr << "Error: PseudoInverse is WRONG-2" << std::endl;
         exit(1);
     }
-    */
     return 0;
 }


### PR DESCRIPTION
- correct failing test due to non-initialized memory
- use a sparseMatrix to store the diagonal S in the svd.
- return the transposed V in the svd