### PR TITLE
tell cmake to use rpath to avoid having to set DYLD_LIBRARY_PATH

### DIFF
--- a/OpenMEEG/cmake/OpenMEEGOptions.cmake
+++ b/OpenMEEG/cmake/OpenMEEGOptions.cmake
@@ -1,3 +1,7 @@
+# Tell CMake to use rpath with the libs we build
+set(CMAKE_MACOSX_RPATH 1)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
 # Set CMAKE_BUILD_TYPE to Release by default.
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING


### PR DESCRIPTION
this avoids the need to set DYLD_LIBRARY_PATH on my mac after doing a make install in a custom folder.

maybe this can be helpful for our problem on mac @eolivi 