### PR TITLE
on cleaning cmake targets

### DIFF
--- a/cmake/externals/ConfigureExternalProjects.cmake
+++ b/cmake/externals/ConfigureExternalProjects.cmake
@@ -111,6 +111,7 @@ macro(subprojects)
         && echo To build them, run the build target: 'cmake --build . --target build'
     )
 
+    #add_custom_target(build ALL DEPENDS ${build_dependencies})
     add_custom_target(build DEPENDS ${build_dependencies})
 
     if (BUILD_TESTING)
@@ -121,5 +122,5 @@ macro(subprojects)
         install(DIRECTORY ${i}/ USE_SOURCE_PERMISSIONS DESTINATION ${CMAKE_INSTALL_PREFIX})
     endforeach()
 
-    add_custom_target(clean DEPENDS ${CLEAN_TARGETS})
+    #add_custom_target(clean DEPENDS ${CLEAN_TARGETS})
 endmacro()


### PR DESCRIPTION
@papadop  please, you told me you could do something concerning the targets.

The problems are: 
- that they do not depend correctly on each other.
- the default target 'ALL' need to depend on build (that should itself depend on build-OpenMEEG AND install-OpenMEEG, ... )
- there are targets created by ExternalProject function (in cmake/SetTargets.cmake), they are called OpenMEEG-configure (or more generraly ${ep}-${target}), whereas the one you use in EP_AddCustomTargets are called build-OpenMEEG, ... etc (or more generraly ${target}-${ep}). I think this one source of the problems.

I've remove one custom clean target as it is dupplicated (cmake says), but please check dependencies.

Thank you