### PR TITLE
H2 ecogm

### DIFF
--- a/OpenMEEG/libs/OpenMEEG/include/DataTag.H
+++ b/OpenMEEG/libs/OpenMEEG/include/DataTag.H
@@ -66,7 +66,7 @@ namespace Types {
 #pragma warning (disable: 4290)	// this particular throw is not the one Visual 2005 is waiting for
 #endif
     template <typename T>
-    std::istream& operator>>(std::istream& is,Types::DataTag<T>& tag) throw(std::io_except::read_error) {
+    std::istream& operator>>(std::istream& is,Types::DataTag<T>& tag) {
 #if WIN32
 #pragma warning (default: 4290)
 #endif

--- a/OpenMEEG/libs/OpenMEEG/include/Properties.H
+++ b/OpenMEEG/libs/OpenMEEG/include/Properties.H
@@ -55,7 +55,7 @@ namespace Utils {
         public:
             BadPropertyFile(const std::string& name):
                 std::runtime_error("Wrong property file"),filename(name) { }
-            ~BadPropertyFile() throw() { }
+            ~BadPropertyFile() noexcept { }
             std::string filename;
         };
 
@@ -149,7 +149,7 @@ namespace Utils {
                 return it->second; 
             }
 
-            void define(const Id& id,const Property& prop) throw(char*) {
+            void define(const Id& id,const Property& prop) {
                 if (base::find(id)!=base::end())
                     throw MultiplyDefinedProperty<Id>(id);
                 base::insert(typename base::value_type(id,prop));

--- a/OpenMEEG/libs/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/libs/OpenMEEG/include/assemble.h
@@ -51,85 +51,85 @@ namespace OpenMEEG {
 
     class OPENMEEG_EXPORT HeadMat: public virtual SymMatrix {
     public:
-        HeadMat (const Geometry& geo, const unsigned gauss_order=3);
+        HeadMat (const Geometry& geo,const unsigned gauss_order=3);
         virtual ~HeadMat () {};
     };
 
     class OPENMEEG_EXPORT SurfSourceMat: public virtual Matrix {
     public:
-        SurfSourceMat (const Geometry& geo, Mesh& sources, const unsigned gauss_order=3);
+        SurfSourceMat (const Geometry& geo,Mesh& sources,const unsigned gauss_order=3);
         virtual ~SurfSourceMat () {};
     };
 
     class OPENMEEG_EXPORT DipSourceMat: public virtual Matrix {
     public:
-        DipSourceMat (const Geometry& geo, const Matrix& dipoles, const unsigned gauss_order=3,
-                      const bool adapt_rhs = true, const std::string& domain_name = "");
+        DipSourceMat (const Geometry& geo,const Matrix& dipoles,const unsigned gauss_order=3,
+                      const bool adapt_rhs = true,const std::string& domain_name = "");
         virtual ~DipSourceMat () {};
     };
 
     class OPENMEEG_EXPORT EITSourceMat: public virtual Matrix {
     public:
-        EITSourceMat(const Geometry& geo, const Sensors& electrodes, const unsigned gauss_order=3);
+        EITSourceMat(const Geometry& geo,const Sensors& electrodes,const unsigned gauss_order=3);
         virtual ~EITSourceMat () {};
     };
 
     class OPENMEEG_EXPORT Surf2VolMat: public virtual Matrix {
     public:
         using Matrix::operator=;
-        Surf2VolMat(const Geometry& geo, const Matrix& points);
+        Surf2VolMat(const Geometry& geo,const Matrix& points);
         virtual ~Surf2VolMat () {};
     };
 
     class OPENMEEG_EXPORT Head2EEGMat: public virtual SparseMatrix {
     public:
-        Head2EEGMat (const Geometry& geo, const Sensors& electrodes);
+        Head2EEGMat (const Geometry& geo,const Sensors& electrodes);
         virtual ~Head2EEGMat () {};
     };
 
     class OPENMEEG_EXPORT Head2ECoGMat: public virtual SparseMatrix {
     public:
-        Head2ECoGMat (const Geometry& geo, const Sensors& electrodes, const Interface& i);
-        Head2ECoGMat (const Geometry& geo, const Sensors& electrodes, const std::string& id); // mainly for SWIG
+        Head2ECoGMat(const Geometry& geo,const Sensors& electrodes,const Interface& i);
+        Head2ECoGMat(const Geometry& geo,const Sensors& electrodes,const std::string& id); // mainly for SWIG
         virtual ~Head2ECoGMat () {};
     };
 
     class OPENMEEG_EXPORT Head2MEGMat: public virtual Matrix {
     public:
-        Head2MEGMat (const Geometry& geo, const Sensors& sensors);
+        Head2MEGMat (const Geometry& geo,const Sensors& sensors);
         virtual ~Head2MEGMat () {};
     };
 
     class OPENMEEG_EXPORT SurfSource2MEGMat: public virtual Matrix {
     public:
-        SurfSource2MEGMat (const Mesh& sources, const Sensors& sensors);
+        SurfSource2MEGMat (const Mesh& sources,const Sensors& sensors);
         virtual ~SurfSource2MEGMat () {};
     };
 
     class OPENMEEG_EXPORT DipSource2MEGMat: public virtual Matrix {
     public:
-        DipSource2MEGMat(const Matrix& dipoles, const Sensors& sensors);
+        DipSource2MEGMat(const Matrix& dipoles,const Sensors& sensors);
         virtual ~DipSource2MEGMat () {};
     };
 
     class OPENMEEG_EXPORT DipSource2InternalPotMat: public virtual Matrix {
     public:
-        DipSource2InternalPotMat(const Geometry& geo, const Matrix& dipoles,
-                                 const Matrix& points, const std::string& domain_name = "");
+        DipSource2InternalPotMat(const Geometry& geo,const Matrix& dipoles,
+                                 const Matrix& points,const std::string& domain_name = "");
         virtual ~DipSource2InternalPotMat () {};
     };
 
     class OPENMEEG_EXPORT CorticalMat: public virtual Matrix {
     public:
-        CorticalMat (const Geometry& geo, const Head2EEGMat& M, const std::string& domain_name = "CORTEX",
-                const unsigned gauss_order=3, double alpha=-1., double beta=-1., const std::string &filename="");
+        CorticalMat (const Geometry& geo,const Head2EEGMat& M,const std::string& domain_name = "CORTEX",
+                const unsigned gauss_order=3,double alpha=-1.,double beta=-1.,const std::string &filename="");
         virtual ~CorticalMat () {};
     };
 
     class OPENMEEG_EXPORT CorticalMat2: public virtual Matrix {
     public:
-        CorticalMat2(const Geometry& geo, const Head2EEGMat& M, const std::string& domain_name = "CORTEX",
-                const unsigned gauss_order=3, double gamma=1., const std::string &filename="");
+        CorticalMat2(const Geometry& geo,const Head2EEGMat& M,const std::string& domain_name = "CORTEX",
+                     const unsigned gauss_order=3,double gamma=1.,const std::string &filename="");
         virtual ~CorticalMat2() {};
     };
 }

--- a/OpenMEEG/libs/OpenMEEG/include/domain.h
+++ b/OpenMEEG/libs/OpenMEEG/include/domain.h
@@ -63,13 +63,13 @@ namespace OpenMEEG {
 
         HalfSpace() { }
 
-        HalfSpace(Interface& _interface,const bool _inside): base(_interface,_inside) { }
+        HalfSpace(Interface& interf,const bool ins): base(interf,ins) { }
 
         ~HalfSpace() { }
 
-              Interface& interface()       { return this->first;  }
-        const Interface& interface() const { return this->first;  }
-        const bool &     inside()    const { return this->second; }
+              Interface& interface()       { return base::first;  }
+        const Interface& interface() const { return base::first;  }
+        const bool       inside()    const { return base::second; }
     };
 
     /// \brief a Domain is a vector of HalfSpace

--- a/OpenMEEG/libs/OpenMEEG/include/geometry_reader.h
+++ b/OpenMEEG/libs/OpenMEEG/include/geometry_reader.h
@@ -49,25 +49,30 @@ knowledge of the CeCILL-B license and that you accept its terms.
 namespace OpenMEEG {
 
     /// \brief A class to read geometry and cond file
+
     class GeometryReader {
-        public:
-            GeometryReader(Geometry& geo): geo_(geo) {};
+    public:
 
-            /// \brief read a geometry file
-            void read_geom(const std::string&);
+        GeometryReader(Geometry& g): geom(g) {};
 
-            /// \brief read a cond file
-            void read_cond(const std::string&);
+        /// \brief read a geometry file
 
-        private:
-            Geometry& geo_;
+        void read_geom(const std::string&);
 
-            /// \return true if name is a realtive path. \param name
-            bool is_relative_path(const std::string& name);
+        /// \brief read a cond file
+
+        void read_cond(const std::string&);
+
+    private:
+
+        Geometry& geom;
+
+        /// \return true if name is a realtive path. \param name
+        bool is_relative_path(const std::string& name);
         #if WIN32
-            static const char PathSeparator[];
+        static const char PathSeparator[];
         #else
-            static const char PathSeparator   = '/';
+        static const char PathSeparator   = '/';
         #endif
     };
     #if WIN32
@@ -77,14 +82,14 @@ namespace OpenMEEG {
     bool GeometryReader::is_relative_path(const std::string& name) {
     #if WIN32
         const char c0 = name[0];
-        if ( c0 == '/' || c0 == '\\' ) {
+        if (c0=='/' || c0=='\\') {
             return false;
         }
         const char c1 = name[1];
         const char c2 = name[2];
-        return !( std::isalpha(c0) && c1 == ':' && ( c2 == '/' || c2 == '\\' ) );
+        return !(std::isalpha(c0) && c1==':' && (c2=='/' || c2=='\\'));
     #else
-        return ( name[0] != PathSeparator );
+        return (name[0] != PathSeparator);
     #endif
     }
 
@@ -98,7 +103,8 @@ namespace OpenMEEG {
         //     - The first section is optional (for backward compatibility).
         //       Starting with the keyword "MeshFile", it follows the path to the VTK/vtp file containing the meshes.
         //       OR
-        //       Starting with the keyword "Meshes", it follows the number of meshes, and the paths to the meshes (with the keyword "Mesh").
+        //       Starting with the keyword "Meshes", it follows the number of meshes, and the paths to the meshes
+        //       (with the keyword "Mesh").
         //
         //     - the second section is introduced by the keyword "Interfaces" followed by a number
         //       (the number of interfaces) and optionnally the keyword "Mesh" (for backward compatibility).
@@ -116,104 +122,114 @@ namespace OpenMEEG {
         
         std::ifstream ifs(geometry.c_str());
 
-        if ( !ifs.is_open() ) {
+        if (!ifs.is_open())
             throw OpenMEEG::OpenError(geometry);
-        }
 
-        unsigned Dd_version[2]; ///< version of the domain description
-        ifs >> io_utils::match("# Domain Description ") >> Dd_version[0] >> io_utils::match(".") >> Dd_version[1];
-        if ( ifs.fail() ) {
+        unsigned version[2]; ///< version of the domain description
+        ifs >> io_utils::match("# Domain Description ") >> version[0] >> io_utils::match(".") >> version[1];
+
+        if (ifs.fail())
             throw OpenMEEG::WrongFileFormat(geometry);
-        }
 
-        // extract the absolut path of geometry file
-        const std::string::size_type pos = geometry.find_last_of(this->PathSeparator);
-        const std::string path = (pos == std::string::npos) ? "" : geometry.substr(0, pos+1);
-
-        // Process meshes. -----------------------------------------------------------------------------------
-        if ( Dd_version[0] == 1 ) {
-            if ( Dd_version[1] == 0 ) {
+        geom.version_id = Geometry::UNKNOWN_VERSION;
+        if (version[0]==1) {
+            if (version[1]==0) {
+                geom.version_id = Geometry::VERSION10;
                 std::cerr << "(DEPRECATED) Please consider updating your geometry file to the new format 1.1 (see data/README.rst): "
                           << geometry << std::endl;
-            } else if ( Dd_version[1] == 1 ) {
-                // Read the mesh section of the description file.
-                // Try to load the meshfile (VTK::vtp file)
-                // or try to load the meshes
-                bool Is_MeshFile, Is_Meshes;
-                ifs >> io_utils::skip_comments("#") >> io_utils::match_optional("MeshFile", Is_MeshFile);
-                ifs >> io_utils::skip_comments("#") >> io_utils::match_optional("Meshes", Is_Meshes);
-                if ( Is_MeshFile ) {
-                    std::string name;
-                    ifs >> io_utils::skip_comments("#") >> io_utils::filename(name, '"', false);
-                    const std::string& full_name = (is_relative_path(name))?path+name:name;
-                    geo_.load_vtp(full_name);
-                } else if ( Is_Meshes ) {
-                    unsigned nb_meshes;
-                    ifs >> nb_meshes;
-                    std::vector<std::string> meshname(nb_meshes); // names
-                    std::vector<std::string> filename(nb_meshes);
-                    std::vector<std::string> fullname(nb_meshes);
-                    Meshes meshes(nb_meshes);
-                    for ( unsigned i = 0; i < nb_meshes; ++i ) {
-                        bool unnamed;
-                        ifs >> io_utils::skip_comments("#") >> io_utils::match_optional("Mesh:", unnamed);
-                        if ( unnamed ) {
-                            ifs >> io_utils::filename(filename[i], '"', false);
-                            std::stringstream defaultname;
-                            defaultname << i+1;
-                            meshname[i] = defaultname.str();
-                        } else {
-                            ifs >> io_utils::match("Mesh") 
-                                >> io_utils::token(meshname[i], ':') 
-                                >> io_utils::filename(filename[i], '"', false);
-                        }
-                        fullname[i] = (is_relative_path(filename[i]))?path+filename[i]:filename[i];
-                        // Load the mesh.
-                        meshes[i].load(fullname[i], false);
-						meshes[i].name() = meshname[i];
-                    }
-                    // Now properly load the meshes into the geometry (not dupplicated vertices)
-                    geo_.import_meshes(meshes);
-                }
-            } else {
-                std::cerr << "Domain Description version not available !" << std::endl;
-                throw OpenMEEG::WrongFileFormat(geometry);
             }
-        } else {
+            if (version[1]==1)
+                geom.version_id = Geometry::VERSION11;
+        }
+        if (geom.version_id==Geometry::UNKNOWN_VERSION) {
             std::cerr << "Domain Description version not available !" << std::endl;
             throw OpenMEEG::WrongFileFormat(geometry);
         }
 
-        // Process interfaces. -----------------------------------------------------------------------------------
+        // Extract the absolute path of geometry file.
+
+        const std::string::size_type pos = geometry.find_last_of(this->PathSeparator);
+        const std::string path = (pos==std::string::npos) ? "" : geometry.substr(0, pos+1);
+
+        // Process meshes.
+
+        if (geom.version_id==Geometry::VERSION11) {
+            // Read the mesh section of the description file.
+            // Try to load the meshfile (VTK::vtp file)
+            // or try to load the meshes
+            bool Is_MeshFile, Is_Meshes;
+            ifs >> io_utils::skip_comments("#") >> io_utils::match_optional("MeshFile", Is_MeshFile);
+            ifs >> io_utils::skip_comments("#") >> io_utils::match_optional("Meshes", Is_Meshes);
+            if (Is_MeshFile) {
+                std::string name;
+                ifs >> io_utils::skip_comments("#") >> io_utils::filename(name, '"', false);
+                const std::string& full_name = (is_relative_path(name))?path+name:name;
+                geom.load_vtp(full_name);
+            } else if (Is_Meshes) {
+                unsigned nb_meshes;
+                ifs >> nb_meshes;
+                std::vector<std::string> meshname(nb_meshes); // names
+                std::vector<std::string> filename(nb_meshes);
+                std::vector<std::string> fullname(nb_meshes);
+                Meshes meshes(nb_meshes);
+                for (unsigned i = 0; i < nb_meshes; ++i) {
+                    bool unnamed;
+                    ifs >> io_utils::skip_comments("#") >> io_utils::match_optional("Mesh:", unnamed);
+                    if (unnamed) {
+                        ifs >> io_utils::filename(filename[i], '"', false);
+                        std::stringstream defaultname;
+                        defaultname << i+1;
+                        meshname[i] = defaultname.str();
+                    } else {
+                        ifs >> io_utils::match("Mesh") 
+                            >> io_utils::token(meshname[i], ':') 
+                            >> io_utils::filename(filename[i], '"', false);
+                    }
+                    fullname[i] = (is_relative_path(filename[i]))?path+filename[i]:filename[i];
+                    // Load the mesh.
+                    meshes[i].load(fullname[i], false);
+                    meshes[i].name() = meshname[i];
+                }
+                // Now properly load the meshes into the geometry (not dupplicated vertices)
+                geom.import_meshes(meshes);
+            }
+        }
+
+        // Process interfaces.
+
         unsigned nb_interfaces;
         bool trash; // backward compatibility, catch "Mesh" optionnally.
         ifs >> io_utils::skip_comments('#')
             >> io_utils::match("Interfaces") >> nb_interfaces >> io_utils::match_optional("Mesh", trash);
 
-        if ( ifs.fail() ) {
+        if (ifs.fail())
             throw OpenMEEG::WrongFileFormat(geometry);
-        }
 
-        // load the interfaces
+        // Load the interfaces
+
         std::string id; // id of mesh/interface/domain
         Interfaces interfaces;
-        // if meshes are not already loaded
-        if ( geo_.nb_meshes() == 0 ) { // ---------------------------------------
-            geo_.meshes_.reserve(nb_interfaces);
+
+        // If meshes are not already loaded
+        
+        if (geom.nb_meshes()==0) {
+            geom.meshes_.reserve(nb_interfaces);
             std::vector<std::string> interfacename(nb_interfaces);
             std::vector<std::string> filename(nb_interfaces);
             std::vector<std::string> fullname(nb_interfaces);
+
             // First read the total number of vertices
+
             unsigned nb_vertices = 0;
-            for ( unsigned i = 0; i < nb_interfaces; ++i ) {
+            for (unsigned i = 0; i < nb_interfaces; ++i) {
                 bool unnamed;
                 ifs >> io_utils::skip_comments("#") >> io_utils::match_optional("Interface:", unnamed);
-                if ( unnamed ) {
+                if (unnamed) {
                     ifs >> io_utils::filename(filename[i], '"', false);
                     std::stringstream defaultname;
                     defaultname << i+1;
                     interfacename[i] = defaultname.str();
-                } else if ( Dd_version[1] == 0 ) { // backward compatibility
+                } else if (geom.version_id==Geometry::VERSION10) { // backward compatibility
                     std::stringstream defaultname;
                     defaultname << i+1;
                     interfacename[i] = defaultname.str();
@@ -227,24 +243,26 @@ namespace OpenMEEG {
                 fullname[i] = (is_relative_path(filename[i]))?path+filename[i]:filename[i];
                 nb_vertices += m.load(fullname[i], false, false); 
             }
-            geo_.vertices_.reserve(nb_vertices);
+            geom.vertices_.reserve(nb_vertices);
+
             // Second really load the meshes
-            for ( unsigned i = 0; i < nb_interfaces; ++i ) {
-                geo_.meshes_.push_back(Mesh(geo_.vertices_, interfacename[i]));
-                geo_.meshes_[i].load(fullname[i], false);
-                interfaces.push_back( Interface(interfacename[i]) );
-                interfaces[i].push_back(OrientedMesh(geo_.meshes_[i], true)); // one mesh per interface, (well oriented)
+
+            for (unsigned i=0;i<nb_interfaces;++i) {
+                geom.meshes_.push_back(Mesh(geom.vertices_, interfacename[i]));
+                geom.meshes_[i].load(fullname[i], false);
+                interfaces.push_back(Interface(interfacename[i]));
+                interfaces[i].push_back(OrientedMesh(geom.meshes_[i], true)); // one mesh per interface, (well oriented)
             }
-        } else { // -----------------------
+        } else {
             std::string interfacename;
-            for ( unsigned i = 0; i < nb_interfaces; ++i ) {
+            for (unsigned i = 0; i < nb_interfaces; ++i) {
                 bool unnamed;
                 std::string line; // extract a line and parse it
                 ifs >> io_utils::skip_comments("#");
                 std::getline(ifs, line);
                 std::istringstream iss(line);
                 iss >> io_utils::match_optional("Interface:", unnamed);
-                if ( unnamed ) {
+                if (unnamed) {
                     std::stringstream defaultname;
                     defaultname << i+1;
                     interfacename = defaultname.str();
@@ -252,50 +270,51 @@ namespace OpenMEEG {
                     iss >> io_utils::match("Interface")
                         >> io_utils::token(interfacename, ':');
                 }
-                interfaces.push_back( interfacename );
-                while ( iss >> id ) {
+                interfaces.push_back(interfacename);
+                while (iss >> id) {
                     bool oriented = true; // does the id starts with a '-' or a '+' ?
-                    if ( ( id[0] == '-' ) || ( id[0] == '+' ) ) {
-                        oriented = ( id[0] == '+' );
+                    if ((id[0]=='-') || (id[0]=='+')) {
+                        oriented = (id[0]=='+');
                         id = id.substr(1, id.size());
                     }
-                    interfaces[i].push_back(OrientedMesh(geo_.mesh(id), oriented));
+                    interfaces[i].push_back(OrientedMesh(geom.mesh(id), oriented));
                 }
             }
         }
 
-        // Process domains. -----------------------------------------------------------------------------------
+        // Process domains.
+
         unsigned num_domains;
         ifs >> io_utils::skip_comments('#') >> io_utils::match("Domains") >> num_domains;
 
-        if ( ifs.fail() ) {
+        if (ifs.fail())
             throw OpenMEEG::WrongFileFormat(geometry);
-        }
 
-        geo_.domains_.resize(num_domains);
-        for ( Domains::iterator dit = geo_.domain_begin(); dit != geo_.domain_end(); ++dit) {
+        geom.domains_.resize(num_domains);
+        for (Domains::iterator dit = geom.domain_begin(); dit != geom.domain_end(); ++dit) {
             std::string line;
-            if ( Dd_version[1] == 0 ) { // backward compatibility
-                ifs >> io_utils::skip_comments('#') >> io_utils::match("Domain") >> dit->name();
+            ifs >> io_utils::skip_comments('#') >> io_utils::match("Domain");
+            if (geom.version_id==Geometry::VERSION10) { // backward compatibility
+                ifs >> dit->name();
             } else {
-                ifs >> io_utils::skip_comments('#') >> io_utils::match("Domain") >> io_utils::token(dit->name(), ':');
+                ifs >> io_utils::token(dit->name(),':');
             }
             getline(ifs, line);
             std::istringstream iss(line);
-            while ( iss >> id ) {
+            while (iss >> id) {
                 bool found = false;
                 bool inside = false; // does the id starts with a '-' or a '+' ?
-                if ( ( id[0] == '-' ) || ( id[0] == '+' ) ) {
-                    inside = ( id[0] == '-' );
+                if ((id[0]=='-') || (id[0]=='+')) {
+                    inside = (id[0]=='-');
                     id = id.substr(1, id.size());
-                } else if ( id == "shared" ) {
+                } else if (id=="shared") {
                     std::cerr << "(DEPRECATED) Keyword shared is useless. Please consider updating your geometry file to the new format 1.1 (see data/README.rst): " << geometry << std::endl;
                     break;                    
                 }
-                for ( Interfaces::iterator iit = interfaces.begin(); iit != interfaces.end() ; ++iit) {
-                    if ( iit->name() == id ) {
+                for (Interfaces::iterator iit = interfaces.begin(); iit != interfaces.end() ; ++iit) {
+                    if (iit->name()==id) {
                         found = true;
-                        if ( !iit->check() ) { // check and correct global orientation
+                        if (!iit->check()) { // check and correct global orientation
                             std::cerr << "Interface \"" << iit->name() << "\" is not closed !" << std::endl;
                             std::cerr << "Please correct a mesh orientation when defining the interface in the geometry file." << std::endl;
                             exit(1);
@@ -303,77 +322,71 @@ namespace OpenMEEG {
                         dit->push_back(HalfSpace(*iit, inside));
                     }
                 }
-                if ( !found ) {
+                if (!found)
                     throw OpenMEEG::NonExistingDomain<std::string>(dit->name(), id);
-                }
             }
         }
 
         // Search for the outermost domain and set boolean OUTERMOST on the domain in the vector domains.
         // An outermost domain is (here) defined as the only domain outside represented by only one interface.
-        bool outer;
+
         Domains::iterator dit_out;
-        for ( Domains::iterator dit = geo_.domain_begin(); dit != geo_.domain_end(); ++dit) {
-            outer = true;
-            for ( Domain::iterator hit = dit->begin(); hit != dit->end(); ++hit) {
+        for (Domains::iterator dit=geom.domain_begin();dit!=geom.domain_end();++dit) {
+            bool outer = true;
+            for (Domain::iterator hit=dit->begin();hit!=dit->end();++hit)
                 outer = outer && !(hit->inside());
+            if (outer) {
                 dit_out = dit;
-            }
-            if ( outer ) {
                 dit_out->outermost() = true;
-                for (Domain::iterator hit = dit_out->begin(); hit != dit_out->end(); ++hit) {
+                for (Domain::iterator hit = dit_out->begin(); hit != dit_out->end(); ++hit)
                     hit->interface().set_to_outermost();
-                }
                 break;
             }
         }
 
-        bool nested = true;
         // Determine if the geometry is nested or not
         // The geometry is considered non nested if (at least) one domain is defined as being outside two or more interfaces
         // OR
         // if 2 interfaces are composed by a same mesh oriented once correctly once wrongly.
-        for ( Domains::const_iterator dit = geo_.domain_begin(); dit != geo_.domain_end(); ++dit) {
+
+        bool nested = true;
+        for (Domains::const_iterator dit=geom.domain_begin();dit!=geom.domain_end();++dit) {
             unsigned out_interface = 0;
-            if ( dit != dit_out ) {
-                for ( Domain::const_iterator hit = dit->begin(); hit != dit->end(); ++hit) {
-                    if ( !hit->inside() ) {
+            if (dit!=dit_out)
+                for (Domain::const_iterator hit = dit->begin(); hit!=dit->end(); ++hit)
+                    if (!hit->inside())
                         out_interface++;
-                    }
-                }
-            }
-            if ( out_interface >= 2 ) {
+
+            if (out_interface>=2) {
                 nested = false;
                 break;
             }
         }
 
-        if ( nested ) {
-            for ( Geometry::const_iterator mit = geo_.begin(); mit != geo_.end(); ++mit) {
+        if (nested) {
+            for (Geometry::const_iterator mit = geom.begin(); mit!=geom.end(); ++mit) {
                 unsigned m_oriented = 0;
-                for ( Domains::const_iterator dit = geo_.domain_begin(); dit != geo_.domain_end(); ++dit) {
-                    for ( Domain::const_iterator hit = dit->begin(); hit != dit->end(); ++hit) {
-                        for ( Interface::const_iterator iit = hit->first.begin(); iit != hit->first.end(); ++iit) {
-                            if ( iit->mesh() == *mit ) {
+                for (Domains::const_iterator dit = geom.domain_begin(); dit!=geom.domain_end(); ++dit)
+                    for (Domain::const_iterator hit = dit->begin(); hit!=dit->end(); ++hit)
+                        for (Interface::const_iterator iit = hit->first.begin(); iit!=hit->first.end(); ++iit)
+                            if (iit->mesh()==*mit)
                                 m_oriented += (iit->orientation());
-                            }
-                        }
-                    }
-                }
-                if ( m_oriented == 0 ) {
+                if (m_oriented==0) {
                     nested = false; // TODO unless a mesh is defined but unused ...
                     break;
                 }
             }
         }
+
         // TODO test model HeadNNa0 appears as non-nested even if it is nested
-        geo_.is_nested_ = nested;
 
-        if ( ifs.fail() ) {
+        geom.is_nested_ = nested;
+
+        if (ifs.fail())
             throw OpenMEEG::WrongFileFormat(geometry);
-        }
 
-        // Close the input file. -----------------------------------------------------------------------------------
+        // Close the input file.
+
         ifs.close();
     }
 
@@ -384,11 +397,12 @@ namespace OpenMEEG {
 
         // Store the internal conductivity of the external boundary of domain i
         // and store the external conductivity of the internal boundary of domain i
-        for ( Domains::iterator dit = geo_.domain_begin(); dit != geo_.domain_end(); ++dit) {
+
+        for (Domains::iterator dit = geom.domain_begin(); dit!=geom.domain_end(); ++dit) {
             try {
                 const Conductivity<double>& cond = properties.find(dit->name());
                 dit->sigma() =  cond.sigma();
-            } catch( const Utils::Properties::UnknownProperty<HeadProperties::Id>& e) {
+            } catch(const Utils::Properties::UnknownProperty<HeadProperties::Id>& e) {
                 throw OpenMEEG::BadDomain(dit->name());
             }
         }

--- a/OpenMEEG/libs/OpenMEEG/include/interface.h
+++ b/OpenMEEG/libs/OpenMEEG/include/interface.h
@@ -50,8 +50,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 namespace OpenMEEG {
 
     /// An Oriented Mesh is a mesh associated with a boolean stating if it is well oriented. 
-    class OrientedMesh: public std::pair<Mesh *, bool> 
-    {
+    class OrientedMesh: public std::pair<Mesh *, bool> {
         typedef std::pair<Mesh *, bool> base;
 
     public:
@@ -76,16 +75,18 @@ namespace OpenMEEG {
         typedef Mesh::VectPTriangle VectPTriangle;
 
         /// Default Constructor
-        Interface(): name_(""), outermost_(false) { }
+        Interface(): interface_name(""), outermost_(false) { }
         
         /// Constructor from a name
-        Interface(const std::string _name): name_(_name), outermost_(false) { }
+        Interface(const std::string& name): interface_name(name), outermost_(false) { }
 
-        const std::string   name()                       const      { return name_; } ///< \return Interface name
-        const bool &        outermost()                  const      { return outermost_; } ///< \return true if it is the outermost interface.
-              void          set_to_outermost(); ///< set all interface meshes to outermost state.
-              bool          contains_point(const Vect3& p) const; ///< \param p a point \return true if point is inside interface
-              bool          check(bool checked = false); ///< Check the global orientation
+        const std::string name() const { return interface_name; } ///< \return Interface name
+
+        const bool& outermost() const { return outermost_; } ///< \return true if it is the outermost interface.
+        void        set_to_outermost(); ///< set all interface meshes to outermost state.
+
+        bool contains_point(const Vect3& p) const; ///< \param p a point \return true if point is inside interface
+        bool check(bool checked = false); ///< Check the global orientation
 
         /// \return the total number of the interface vertices
         size_t nb_vertices() const {
@@ -119,7 +120,7 @@ namespace OpenMEEG {
 
         double compute_solid_angle(const Vect3& p) const; ///< Given a point p, it computes the solid angle \return should return +/- 4 PI or 0.
 
-        std::string name_;      ///< is "" by default
+        std::string interface_name;      ///< is "" by default
         bool        outermost_; ///< tell weather or not the interface touches the Air (Outermost) Domain.
     };
 

--- a/OpenMEEG/libs/OpenMEEG/src/assembleSensors.cpp
+++ b/OpenMEEG/libs/OpenMEEG/src/assembleSensors.cpp
@@ -45,142 +45,145 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 namespace OpenMEEG {
 
-    void assemble_ferguson(const Geometry& geo, Matrix& mat, const Matrix& pts);
+    void assemble_ferguson(const Geometry& geo,Matrix& mat,const Matrix& pts);
 
     // EEG patches positions are reported line by line in the positions Matrix
     // mat is supposed to be filled with zeros
     // mat is the linear application which maps x (the unknown vector in symmetric system) -> v (potential at the electrodes)
-    void assemble_Head2EEG(SparseMatrix& mat, const Geometry& geo, const Matrix& positions )
-    {
-        mat = SparseMatrix(positions.nlin(), (geo.size()-geo.nb_current_barrier_triangles()));
+
+    void
+    assemble_Head2EEG(SparseMatrix& mat,const Geometry& geo,const Matrix& positions ) {
+
+        mat = SparseMatrix(positions.nlin(),(geo.size()-geo.nb_current_barrier_triangles()));
 
         Vect3 current_position;
         Vect3 current_alphas;
         Triangle current_triangle;
         for ( unsigned i = 0; i < positions.nlin(); ++i) {
             for ( unsigned k = 0; k < 3; ++k) {
-                current_position(k) = positions(i, k);
+                current_position(k) = positions(i,k);
             }
             double dist;
             dist_point_geom(current_position,geo,current_alphas,current_triangle,dist);
-            mat(i, current_triangle.s1().index()) = current_alphas(0);
-            mat(i, current_triangle.s2().index()) = current_alphas(1);
-            mat(i, current_triangle.s3().index()) = current_alphas(2);
+            mat(i,current_triangle.s1().index()) = current_alphas(0);
+            mat(i,current_triangle.s2().index()) = current_alphas(1);
+            mat(i,current_triangle.s3().index()) = current_alphas(2);
         }
     }
 
-    Head2EEGMat::Head2EEGMat(const Geometry& geo, const Sensors& electrodes)
-    {
-        assemble_Head2EEG(*this, geo, electrodes.getPositions());
+    Head2EEGMat::Head2EEGMat(const Geometry& geo,const Sensors& electrodes) {
+        assemble_Head2EEG(*this,geo,electrodes.getPositions());
     }
 
     // ECoG positions are reported line by line in the positions Matrix
     // mat is supposed to be filled with zeros
     // mat is the linear application which maps x (the unknown vector in symmetric system) -> v (potential at the ECoG electrodes)
     // difference with Head2EEG is that it interpolates the inner skull layer instead of the scalp layer. 
-    void assemble_Head2ECoG(SparseMatrix& mat, const Geometry& geo, const Matrix& positions, const Interface& i)
-    {
-        mat = SparseMatrix(positions.nlin(), (geo.size()-geo.nb_current_barrier_triangles()));
+
+    void
+    assemble_Head2ECoG(SparseMatrix& mat,const Geometry& geo,const Matrix& positions,const Interface& i) {
+        mat = SparseMatrix(positions.nlin(),(geo.size()-geo.nb_current_barrier_triangles()));
 
         Vect3 current_position;
         Vect3 current_alphas;
         Triangle current_triangle;
-        for ( unsigned it = 0; it < positions.nlin(); ++it) {
-            for ( unsigned k = 0; k < 3; ++k) {
-                current_position(k) = positions(it, k);
-            }
-            dist_point_interface(current_position, i, current_alphas, current_triangle);
-            mat(it, current_triangle.s1().index()) = current_alphas(0);
-            mat(it, current_triangle.s2().index()) = current_alphas(1);
-            mat(it, current_triangle.s3().index()) = current_alphas(2);
+        for (unsigned it = 0; it<positions.nlin(); ++it) {
+            for (unsigned k = 0; k<3; ++k)
+                current_position(k) = positions(it,k);
+            dist_point_interface(current_position,i,current_alphas,current_triangle);
+            mat(it,current_triangle.s1().index()) = current_alphas(0);
+            mat(it,current_triangle.s2().index()) = current_alphas(1);
+            mat(it,current_triangle.s3().index()) = current_alphas(2);
         }
     }
 
-    Head2ECoGMat::Head2ECoGMat(const Geometry& geo, const Sensors& electrodes, const Interface& i)
-    {
-        assemble_Head2ECoG(*this, geo, electrodes.getPositions(), i);
+    Head2ECoGMat::Head2ECoGMat(const Geometry& geo,const Sensors& electrodes,const Interface& i) {
+        assemble_Head2ECoG(*this,geo,electrodes.getPositions(),i);
     }
 
-    Head2ECoGMat::Head2ECoGMat(const Geometry& geo, const Sensors& electrodes, const std::string& id)
-    {
-        assemble_Head2ECoG(*this, geo, electrodes.getPositions(), geo.interface(id));
+    Head2ECoGMat::Head2ECoGMat(const Geometry& geo,const Sensors& electrodes,const std::string& id) {
+        assemble_Head2ECoG(*this,geo,electrodes.getPositions(),geo.interface(id));
     }
 
     // MEG patches positions are reported line by line in the positions Matrix (same for positions)
     // mat is supposed to be filled with zeros
     // mat is the linear application which maps x (the unknown vector in symmetric system) -> bFerguson (contrib to MEG response)
-    void assemble_Head2MEG(Matrix& mat, const Geometry& geo, const Sensors& sensors) 
-    {
+
+    void
+    assemble_Head2MEG(Matrix& mat,const Geometry& geo,const Sensors& sensors) {
+
         Matrix positions = sensors.getPositions();
         Matrix orientations = sensors.getOrientations();
         const unsigned nbIntegrationPoints = sensors.getNumberOfPositions();
         unsigned p0_p1_size = (geo.size() - geo.nb_current_barrier_triangles());
 
-        Matrix FergusonMat(3*nbIntegrationPoints, geo.nb_vertices());
+        Matrix FergusonMat(3*nbIntegrationPoints,geo.nb_vertices());
         FergusonMat.set(0.0);
 
-        assemble_ferguson(geo, FergusonMat, positions);
+        assemble_ferguson(geo,FergusonMat,positions);
 
-        mat = Matrix(nbIntegrationPoints, p0_p1_size);
+        mat = Matrix(nbIntegrationPoints,p0_p1_size);
         mat.set(0.0);
 
         for ( unsigned i = 0; i < nbIntegrationPoints; ++i) {
-            PROGRESSBAR(i, nbIntegrationPoints);
+            PROGRESSBAR(i,nbIntegrationPoints);
             for ( Vertices::const_iterator vit = geo.vertex_begin(); vit != geo.vertex_end(); ++vit) {
-                Vect3 fergusonField(FergusonMat(3*i, vit->index()), FergusonMat(3*i+1, vit->index()), FergusonMat(3*i+2, vit->index()));
-                Vect3 normalizedDirection(orientations(i, 0), orientations(i, 1), orientations(i, 2));
+                Vect3 fergusonField(FergusonMat(3*i,vit->index()),FergusonMat(3*i+1,vit->index()),FergusonMat(3*i+2,vit->index()));
+                Vect3 normalizedDirection(orientations(i,0),orientations(i,1),orientations(i,2));
                 normalizedDirection.normalize();
-                mat(i, vit->index()) = fergusonField * normalizedDirection;
+                mat(i,vit->index()) = fergusonField * normalizedDirection;
             }
         }
         mat = sensors.getWeightsMatrix() * mat; // Apply weights
     }
 
-    Head2MEGMat::Head2MEGMat(const Geometry& geo, const Sensors& sensors)
-    {
-        assemble_Head2MEG(*this, geo, sensors);
+    Head2MEGMat::Head2MEGMat(const Geometry& geo,const Sensors& sensors) {
+        assemble_Head2MEG(*this,geo,sensors);
     }
 
     // MEG patches positions are reported line by line in the positions Matrix (same for positions)
     // mat is supposed to be filled with zeros
     // mat is the linear application which maps x (the unknown vector in symmetric system) -> binf (contrib to MEG response)
-    void assemble_SurfSource2MEG(Matrix& mat, const Mesh& sources_mesh, const Sensors& sensors)
-    {
+
+    void
+    assemble_SurfSource2MEG(Matrix& mat,const Mesh& sources_mesh,const Sensors& sensors) {
+
         Matrix positions = sensors.getPositions();
         Matrix orientations = sensors.getOrientations();
         const unsigned nsquids = positions.nlin();
 
-        mat = Matrix(nsquids, sources_mesh.nb_vertices());
+        mat = Matrix(nsquids,sources_mesh.nb_vertices());
         mat.set(0.0);
 
         for ( unsigned i = 0; i < nsquids; ++i) {
-            PROGRESSBAR(i, nsquids);
-            Vect3 p(positions(i, 0), positions(i, 1), positions(i, 2));
-            Matrix FergusonMat(3, mat.ncol());
+            PROGRESSBAR(i,nsquids);
+            Vect3 p(positions(i,0),positions(i,1),positions(i,2));
+            Matrix FergusonMat(3,mat.ncol());
             FergusonMat.set(0.0);
-            operatorFerguson(p, sources_mesh, FergusonMat, 0, 1.);
+            operatorFerguson(p,sources_mesh,FergusonMat,0,1.);
             for ( unsigned j = 0; j < mat.ncol(); ++j) {
-                Vect3 fergusonField(FergusonMat(0, j), FergusonMat(1, j), FergusonMat(2, j));
-                Vect3 normalizedDirection(orientations(i, 0), orientations(i, 1), orientations(i, 2));
+                Vect3 fergusonField(FergusonMat(0,j),FergusonMat(1,j),FergusonMat(2,j));
+                Vect3 normalizedDirection(orientations(i,0),orientations(i,1),orientations(i,2));
                 normalizedDirection.normalize();
-                mat(i, j) = fergusonField * normalizedDirection;
+                mat(i,j) = fergusonField * normalizedDirection;
             }
         }
 
         mat = sensors.getWeightsMatrix() * mat; // Apply weights
     }
 
-    SurfSource2MEGMat::SurfSource2MEGMat(const Mesh& sources_mesh, const Sensors& sensors)
-    {
-        assemble_SurfSource2MEG(*this, sources_mesh, sensors);
+    SurfSource2MEGMat::SurfSource2MEGMat(const Mesh& sources_mesh,const Sensors& sensors) {
+        assemble_SurfSource2MEG(*this,sources_mesh,sensors);
     }
 
     // Creates the DipSource2MEG Matrix with unconstrained orientations for the sources.
     // MEG patches positions are reported line by line in the positions Matrix (same for positions)
     // mat is supposed to be filled with zeros
-    // sources is the name of a file containing the description of the sources - one dipole per line: x1 x2 x3 n1 n2 n3, x being the position and n the orientation.
-    void assemble_DipSource2MEG(Matrix& mat, const Matrix& dipoles, const Sensors& sensors)
-    {
+    // sources is the name of a file containing the description of the sources - one dipole per line: x1 x2 x3 n1 n2 n3,x being the position and n the orientation.
+
+    void
+    assemble_DipSource2MEG(Matrix& mat,const Matrix& dipoles,const Sensors& sensors) {
+
         Matrix positions = sensors.getPositions();
         Matrix orientations = sensors.getOrientations();
 
@@ -190,29 +193,28 @@ namespace OpenMEEG {
         }
 
         // this Matrix will contain the field generated at the location of the i-th squid by the j-th source
-        mat = Matrix(positions.nlin(), dipoles.nlin());
+        mat = Matrix(positions.nlin(),dipoles.nlin());
 
         // the following routine is the equivalent of operatorFerguson for pointlike dipoles.
         for ( unsigned i = 0; i < mat.nlin(); ++i) {
             for ( unsigned j = 0; j < mat.ncol(); ++j) {
-                Vect3 r(dipoles(j, 0), dipoles(j, 1), dipoles(j, 2));
-                Vect3 q(dipoles(j, 3), dipoles(j, 4), dipoles(j,5));
-                Vect3 diff(positions(i, 0), positions(i, 1), positions(i, 2));
+                Vect3 r(dipoles(j,0),dipoles(j,1),dipoles(j,2));
+                Vect3 q(dipoles(j,3),dipoles(j,4),dipoles(j,5));
+                Vect3 diff(positions(i,0),positions(i,1),positions(i,2));
                 diff -= r;
                 double norm_diff = diff.norm();
                 Vect3 fergusonField = q ^ diff / (norm_diff * norm_diff * norm_diff);
-                Vect3 normalizedDirection(orientations(i, 0), orientations(i, 1), orientations(i, 2));
+                Vect3 normalizedDirection(orientations(i,0),orientations(i,1),orientations(i,2));
                 normalizedDirection.normalize();
-                mat(i, j) = fergusonField * normalizedDirection * MU0 / (4.0 * M_PI);
+                mat(i,j) = fergusonField * normalizedDirection * MU0 / (4.0 * M_PI);
             }
         }
 
         mat = sensors.getWeightsMatrix() * mat; // Apply weights
     }
 
-    DipSource2MEGMat::DipSource2MEGMat(const Matrix& dipoles, const Sensors& sensors)
-    {
-        assemble_DipSource2MEG(*this, dipoles, sensors);
+    DipSource2MEGMat::DipSource2MEGMat(const Matrix& dipoles,const Sensors& sensors) {
+        assemble_DipSource2MEG(*this,dipoles,sensors);
     }
 
-} // end namespace OpenMEEG
+}

--- a/OpenMEEG/libs/OpenMEEG/src/geometry.cpp
+++ b/OpenMEEG/libs/OpenMEEG/src/geometry.cpp
@@ -234,15 +234,11 @@ namespace OpenMEEG {
                 if (OLD_ORDERING) {
                     om_error(is_nested_); // OR non nested but without shared vertices
                     for (Mesh::const_vertex_iterator vit = mit->vertex_begin(); vit != mit->vertex_end(); ++vit, ++index) 
-                    {
                         (*vit)->index() = index;
-                    }
                 }
-                if (!mit->isolated()&&!mit->current_barrier()) {
-                    for ( Mesh::iterator tit = mit->begin(); tit != mit->end(); ++tit) {
+                if (!mit->isolated()&&!mit->current_barrier())
+                    for ( Mesh::iterator tit = mit->begin(); tit != mit->end(); ++tit)
                         tit->index() = index++;
-                    }
-                }
             }
             // even the last surface triangles (yes for EIT... )
             nb_current_barrier_triangles_ = 0;

--- a/OpenMEEG/libs/OpenMEEG/src/geometry.cpp
+++ b/OpenMEEG/libs/OpenMEEG/src/geometry.cpp
@@ -43,42 +43,66 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 namespace OpenMEEG {
 
-    const Interface& Geometry::outermost_interface() const {
-        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit) {
-            if (dit->outermost()) {
-                return dit->begin()->interface();
-            }
+    const Interface&
+    Geometry::innermost_interface() const {
+
+        if (!is_nested()) {
+            warning("Geometry::innermost_interface: Error innermost interface is only defined for nested geometries.");
+            throw OpenMEEG::BadInterface("innermost");
         }
 
-        // should never append
+        for (Domains::const_iterator dit=domain_begin();dit!=domain_end();++dit) {
+            bool inner = true;
+            for (Domain::const_iterator hit = dit->begin(); hit!=dit->end(); ++hit)
+                if (!hit->inside()) {
+                    inner = false;
+                    break;
+                }
+            if (inner)
+                return dit->begin()->interface();
+        }
+
+        // Should never append as this function should only be called for nested geometries.
+
+        warning("Geometry::innerermost_interface: Error innermost interface is not defined.");
+        throw OpenMEEG::BadInterface("innermost");
+    }
+
+    const Interface&
+    Geometry::outermost_interface() const {
+        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit)
+            if (dit->outermost())
+                return dit->begin()->interface();
+
+        // Should never append
         warning("Geometry::outermost_interface: Error outermost interface were not set.");
         throw OpenMEEG::BadInterface("outermost");
     }
 
-    Mesh&  Geometry::mesh(const std::string& id) {
-        for (iterator mit = begin(); mit != end(); ++mit ) {
-            if (id == mit->name()) {
+    Mesh&
+    Geometry::mesh(const std::string& id) {
+        for (iterator mit = begin(); mit != end(); ++mit )
+            if (id == mit->name())
                 return *mit;
-            }
-        }
 
-        warning(std::string("Geometry::mesh: Error mesh id/name not found: ") + id);
-        throw OpenMEEG::BadInterface(id);
-        // should never append
-    }
-
-    const Mesh&  Geometry::mesh(const std::string& id) const {
-        for (const_iterator mit = begin(); mit != end(); ++mit) {
-            if (id == mit->name()) {
-                return *mit;
-            }
-        }
-        // should never append
+        // Should never append
         warning(std::string("Geometry::mesh: Error mesh id/name not found: ") + id);
         throw OpenMEEG::BadInterface(id);
     }
 
-    void Geometry::info(const bool verbous) const {
+    const Mesh&
+    Geometry::mesh(const std::string& id) const {
+        for (const_iterator mit = begin(); mit != end(); ++mit)
+            if (id == mit->name())
+                return *mit;
+
+        // Should never append
+        warning(std::string("Geometry::mesh: Error mesh id/name not found: ") + id);
+        throw OpenMEEG::BadInterface(id);
+    }
+
+    void 
+    Geometry::info(const bool verbous) const {
         if (is_nested_) {
             std::cout << "This geometry is a NESTED geometry." << std::endl;
         } else {
@@ -90,74 +114,69 @@ namespace OpenMEEG {
             std::cout << "This geometry is a NON NESTED geometry. (There was " << shared << " demands for adding same vertices)." << std::endl;
         }
 
-        for (const_iterator mit = begin(); mit != end(); ++mit) {
+        for (const_iterator mit = begin(); mit != end(); ++mit)
             mit->info();
-        }
 
-        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit) {
+        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit)
             dit->info();
-        }
 
         if (verbous) {
-            for (Vertices::const_iterator vit = vertex_begin(); vit != vertex_end(); ++vit) {
+            for (Vertices::const_iterator vit = vertex_begin(); vit != vertex_end(); ++vit)
                 std::cout << "[" << *vit << "] = " << vit->index() << std::endl;
-            }
 
-            for (const_iterator mit = begin(); mit != end(); ++mit) {
-                for (Mesh::const_iterator tit = mit->begin(); tit != mit->end(); ++tit) {
+            for (const_iterator mit = begin(); mit != end(); ++mit)
+                for (Mesh::const_iterator tit = mit->begin(); tit != mit->end(); ++tit)
                     std::cout << "[[" << tit->s1() << "] , [" << tit->s2() << "] , ["<< tit->s3() << "]] \t = " << tit->index() << std::endl;
-                }
-            }
         }
     }
 
-    const Interface& Geometry::interface(const std::string& id) const {
-        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit) {
-            for (Domain::const_iterator hit = dit->begin(); hit != dit->end(); ++hit) {
-                if (hit->interface().name() == id) {
+    const Interface&
+    Geometry::interface(const std::string& id) const {
+        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit)
+            for (Domain::const_iterator hit = dit->begin(); hit != dit->end(); ++hit)
+                if (hit->interface().name() == id)
                     return hit->interface();
-                }
-            }
-        }
 
+        // Should never append
         warning(std::string("Geometry::interface: Interface id/name \"") + id + std::string("\" not found."));
         throw OpenMEEG::BadInterface(id);
-        // should never append
     }
 
-    const Domain& Geometry::domain(const Vect3& p) const {
-        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit) {
-            if (dit->contains_point(p)) {
+    const Domain&
+    Geometry::domain(const Vect3& p) const {
+        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit)
+            if (dit->contains_point(p))
                 return *dit;
-            }
-        }
+
+        // Should never append
         throw OpenMEEG::BadDomain("Impossible");
-        // should never append
     }
 
-    const Domain& Geometry::domain(const std::string& dname) const {
-        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit) {
-            if (dit->name() == dname) {
+    const Domain&
+    Geometry::domain(const std::string& dname) const {
+        for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit)
+            if (dit->name() == dname)
                 return *dit;
-            }
-        }
 
-        // should never append
+        // Should never append
         warning(std::string("Geometry::domain: Domain id/name \"") + dname + std::string("\" not found."));
         throw OpenMEEG::BadDomain(dname);
     }
 
-    void Geometry::read(const std::string& geomFileName, const std::string& condFileName, const bool OLD_ORDERING) {
-        // clear all first
+    void
+    Geometry::read(const std::string& geomFileName,const std::string& condFileName,const bool OLD_ORDERING) {
+
+        // First clear all.
+
         vertices_.clear();
         meshes_.clear();
         domains_.clear();
         is_nested_ = has_cond_ = false;
 
-        GeometryReader geoR(*this);
+        GeometryReader reader(*this);
         try {
-            geoR.read_geom(geomFileName);
-        } catch ( OpenMEEG::Exception& e) {
+            reader.read_geom(geomFileName);
+        } catch (OpenMEEG::Exception& e) {
             std::cerr << e.what() << " in the file " << geomFileName << std::endl;
             exit(e.code());
         } catch (...) {
@@ -165,10 +184,10 @@ namespace OpenMEEG {
             exit(1);
         }
 
-        if (condFileName != "") {
+        if (condFileName!="") {
             try {
-                geoR.read_cond(condFileName);
-            } catch ( OpenMEEG::Exception& e) {
+                reader.read_cond(condFileName);
+            } catch (OpenMEEG::Exception& e) {
                 std::cerr << e.what() << " in the file " << condFileName << std::endl;
                 exit(e.code());
             } catch (...) {
@@ -177,19 +196,24 @@ namespace OpenMEEG {
             }
             has_cond_ = true;
 
-            // mark meshes that touch the 0-cond
+            // Mark meshes that touch the 0-cond
+
             mark_current_barrier();
         }
 
-        // generate the indices of our unknowns
+        // Generate the indices of unknowns
+
         generate_indices(OLD_ORDERING);
 
-        // print info
+        // Print info
+        
         info();
     }
 
     // This generates unique indices for vertices and triangles which will correspond to our unknowns.
-    void Geometry::generate_indices(const bool OLD_ORDERING) {
+
+    void
+    Geometry::generate_indices(const bool OLD_ORDERING) {
         // Either unknowns (potentials and currents) are ordered by mesh (i.e. V_1, p_1, V_2, p_2, ...) (this is the OLD_ORDERING)
         // or by type (V_1, V_2, V_3 .. p_1, p_2...) (by DEFAULT)
         // or by the user himself encoded into the vtp file.
@@ -247,26 +271,25 @@ namespace OpenMEEG {
         }
     }
 
-    double Geometry::sigma(const std::string& name) const {
-        for (std::vector<Domain>::const_iterator dit = domain_begin(); dit != domain_end(); ++dit) {
-            if (name == dit->name()) {
+    double
+    Geometry::sigma(const std::string& name) const {
+        for (std::vector<Domain>::const_iterator dit = domain_begin(); dit != domain_end(); ++dit)
+            if (name == dit->name())
                 return dit->sigma();
-            }
-        }
+
         warning(std::string("Geometry::sigma: Domain id/name \"") + name + std::string("\" not found."));
         return 0.;
     }
 
-    const Domains Geometry::common_domains(const Mesh& m1, const Mesh& m2) const {
+    const Domains
+    Geometry::common_domains(const Mesh& m1, const Mesh& m2) const {
         std::set<Domain> sdom1;
         std::set<Domain> sdom2;
         for (Domains::const_iterator dit = domain_begin(); dit != domain_end(); ++dit) {
-            if (dit->mesh_orientation(m1) != 0) {
+            if (dit->mesh_orientation(m1) != 0)
                 sdom1.insert(*dit);
-            }
-            if (dit->mesh_orientation(m2) != 0) {
+            if (dit->mesh_orientation(m2) != 0)
                 sdom2.insert(*dit);
-            }
         }
         Domains doms;
         std::set_intersection(sdom1.begin(), sdom1.end(), sdom2.begin(), sdom2.end(), std::back_inserter(doms));
@@ -274,7 +297,8 @@ namespace OpenMEEG {
     }
 
     /// \return a function (sum, difference, ...) of the conductivity(ies) of the shared domain(s).
-    double Geometry::funct_on_domains(const Mesh& m1, const Mesh& m2, const Function& f) const {
+    double
+    Geometry::funct_on_domains(const Mesh& m1, const Mesh& m2, const Function& f) const {
         Domains doms = common_domains(m1, m2);
         double ans = 0.;
         for (Domains::iterator dit = doms.begin(); dit != doms.end(); ++dit) {
@@ -297,36 +321,41 @@ namespace OpenMEEG {
     }
 
     /// \return the difference of conductivities of the 2 domains.
-    double  Geometry::sigma_diff(const Mesh& m) const {
+    double
+    Geometry::sigma_diff(const Mesh& m) const {
         Domains doms = common_domains(m, m); // Get the 2 domains surrounding mesh m
         double  ans  = 0.;
-        for (Domains::iterator dit = doms.begin(); dit != doms.end(); ++dit) {
+        for (Domains::iterator dit = doms.begin(); dit != doms.end(); ++dit)
             ans += dit->sigma()*dit->mesh_orientation(m);
-        }
         return ans;
     }
 
     /// \return 0. for non communicating meshes, 1. for same oriented meshes, -1. for different orientation
-    int Geometry::oriented(const Mesh& m1, const Mesh& m2) const {
+    int
+    Geometry::oriented(const Mesh& m1, const Mesh& m2) const {
         Domains doms = common_domains(m1, m2); // 2 meshes have either 0, 1 or 2 domains in common
         return (doms.size() == 0) ? 0 : ((doms[0].mesh_orientation(m1) == doms[0].mesh_orientation(m2)) ? 1 : -1);
     }
 
-    bool Geometry::selfCheck() const {
+    bool
+    Geometry::selfCheck() const {
 
         bool OK = true;
 
         // Test that all meshes are well oriented and not (self-)intersecting
+
         for (const_iterator mit1 = begin(); mit1 != end(); ++mit1) {
-            if (!mit1->has_correct_orientation()) {
+
+            if (!mit1->has_correct_orientation())
                 warning(std::string("A mesh does not seem to be properly oriented"));
-            }
+
             if (mit1->has_self_intersection()) {
                 warning(std::string("Mesh is self intersecting !"));
                 mit1->info();
                 OK = false;
                 std::cout << "Self intersection for mesh \"" << mit1->name() << "\"" << std:: endl;
             }
+
             if (is_nested_) {
                 for (const_iterator mit2 = mit1+1; mit2 != end(); ++mit2) {
                     if (mit1->intersection(*mit2)) {
@@ -341,24 +370,26 @@ namespace OpenMEEG {
         return OK;
     }
 
-    bool Geometry::check(const Mesh& m) const {
+    bool
+    Geometry::check(const Mesh& m) const {
         bool OK = true;
         if (m.has_self_intersection()) {
             warning(std::string("Mesh is self intersecting !"));
             m.info();
             OK = false;
         }
-        for (const_iterator mit = begin(); mit != end(); ++mit) {
+        for (const_iterator mit = begin(); mit != end(); ++mit)
             if (mit->intersection(m)) {
                 warning(std::string("Mesh is intersecting with one of the mesh in geom file !"));
                 mit->info();
                 OK = false;
             }
-        }
+
         return OK;
     }
 
-    void Geometry::import_meshes(const Meshes& m) {
+    void
+    Geometry::import_meshes(const Meshes& m) {
         meshes_.clear();
         vertices_.clear();
         unsigned n_vert_max = 0;
@@ -366,9 +397,8 @@ namespace OpenMEEG {
         std::map<const Vertex *, Vertex *> map_vertices;
 
         // count the vertices
-        for (Meshes::const_iterator mit = m.begin(); mit != m.end(); ++mit) {
+        for (Meshes::const_iterator mit = m.begin(); mit != m.end(); ++mit)
             n_vert_max += mit->nb_vertices();
-        }
 
         vertices_.reserve(n_vert_max);
         meshes_.reserve(m.size());
@@ -394,13 +424,14 @@ namespace OpenMEEG {
     }
 
     // mark all meshes which touch domains with 0 conductivity
-    void Geometry::mark_current_barrier() {
+    void
+    Geometry::mark_current_barrier() {
 
         // figure out the connectivity of meshes
         std::vector<int> mesh_idx;
-        for (unsigned i = 0; i < meshes().size(); i++) {
+        for (unsigned i = 0; i < meshes().size(); i++)
             mesh_idx.push_back(i);
-        }
+
         std::vector<std::vector<int> > mesh_conn;
         std::vector<int> mesh_connected, mesh_diff;
         std::set_difference(mesh_idx.begin(), mesh_idx.end(), mesh_connected.begin(), mesh_connected.end(), std::insert_iterator<std::vector<int> >(mesh_diff, mesh_diff.end()));
@@ -430,9 +461,9 @@ namespace OpenMEEG {
 
         // find isolated meshes and touch 0-cond meshes;
         std::set<std::string> touch_0_mesh;
-        for (Domains::iterator dit = domains_.begin(); dit != domains_.end(); ++dit) {
-            if ( almost_equal(dit->sigma(), 0.0)) {
-                for (Domain::iterator hit = dit->begin(); hit != dit->end(); ++hit) {
+        for (Domains::iterator dit = domains_.begin(); dit != domains_.end(); ++dit)
+            if (almost_equal(dit->sigma(), 0.0))
+                for (Domain::iterator hit = dit->begin(); hit != dit->end(); ++hit)
                     for (Interface::iterator omit = hit->first.begin(); omit != hit->first.end(); ++omit) {
                         omit->mesh().current_barrier() = true;
                         std::pair<std::set<std::string>::iterator, bool> ret = touch_0_mesh.insert(omit->mesh().name());
@@ -446,55 +477,40 @@ namespace OpenMEEG {
                             }
                         }
                     }
-                }
-            }
-        }
 
         std::vector<std::vector<int> > new_conn;
-        for (std::vector<std::vector<int> >::const_iterator git = mesh_conn.begin(); git != mesh_conn.end(); ++git) {
-            if (git->size()>1||!meshes()[*git->begin()].isolated()) {
+        for (std::vector<std::vector<int> >::const_iterator git = mesh_conn.begin(); git != mesh_conn.end(); ++git)
+            if (git->size()>1||!meshes()[*git->begin()].isolated())
                 new_conn.push_back(*git);
-            }
-        }
+
         mesh_conn = new_conn;
 
         //do not delete shared vertices
         std::set<Vertex> shared_vtx;
-        for (std::set<Vertex>::const_iterator vit = invalid_vertices_.begin(); vit != invalid_vertices_.end(); ++vit) {
-            for (Meshes::const_iterator mit = begin(); mit != end(); ++mit) {
+        for (std::set<Vertex>::const_iterator vit = invalid_vertices_.begin(); vit != invalid_vertices_.end(); ++vit)
+            for (Meshes::const_iterator mit = begin(); mit != end(); ++mit)
                 if (!mit->isolated()) {
                     std::vector<Vertex*>::const_iterator vfind;
-                    for (vfind = mit->vertex_begin(); vfind != mit->vertex_end(); ++vfind) {
-                        if (**vfind == *vit) {
+                    for (vfind = mit->vertex_begin(); vfind != mit->vertex_end(); ++vfind)
+                        if (**vfind == *vit)
                             break;
-                        }
-                    }
-                    if (vfind != mit->vertex_end()) {
-                        shared_vtx.insert(**vfind); //a shared vertex is found
-                    }
-                }
-            }
-        }
 
-        for (std::set<Vertex>::const_iterator vit = shared_vtx.begin(); vit != shared_vtx.end(); ++vit) {
+                    if (vfind != mit->vertex_end())
+                        shared_vtx.insert(**vfind); //a shared vertex is found
+                }
+
+        for (std::set<Vertex>::const_iterator vit = shared_vtx.begin(); vit != shared_vtx.end(); ++vit)
             invalid_vertices_.erase(*vit);
-        }
 
         //redefine outermost interface
         //the inside of a 0-cond domain is considered as a new outermost
-        for (Domains::iterator dit = domain_begin(); dit != domain_end(); ++dit) {
-            if ( almost_equal(dit->sigma(), 0.0)) {
-                for (Domain::iterator hit = dit->begin(); hit != dit->end(); ++hit) {
-                    if (!hit->inside()) {
-                        for (Interface::iterator omit = hit->first.begin(); omit != hit->first.end(); ++omit) {
-                            if (omit->mesh().current_barrier()&&!omit->mesh().isolated()) {
+        for (Domains::iterator dit = domain_begin(); dit != domain_end(); ++dit)
+            if (almost_equal(dit->sigma(), 0.0))
+                for (Domain::iterator hit = dit->begin(); hit != dit->end(); ++hit)
+                    if (!hit->inside())
+                        for (Interface::iterator omit = hit->first.begin(); omit != hit->first.end(); ++omit)
+                            if (omit->mesh().current_barrier()&&!omit->mesh().isolated())
                                 omit->mesh().outermost() = true;
-                            }
-                        }
-                    }
-                }
-            }
-        }
 
         //detect isolated geometries
         if (mesh_conn.size()>1) {
@@ -503,18 +519,16 @@ namespace OpenMEEG {
 
             for (unsigned iit = 0, p = 0; iit < mesh_conn.size(); ++iit) {
                 std::cout<<"Part "<<++p<<" is formed by meshes: { ";
-                for (unsigned miit = 0; miit < mesh_conn[iit].size(); ++miit) {
-                    std::cout<<"\""<<meshes()[mesh_conn[iit][miit]].name()<<"\" ";
-                }
+                for (unsigned miit = 0; miit < mesh_conn[iit].size(); ++miit)
+                    std::cout << "\"" << meshes()[mesh_conn[iit][miit]].name() << "\" ";
                 std::cout<<"}."<<std::endl;
             }
         }
         //count geo_group
         for (unsigned git = 0; git < mesh_conn.size(); ++git) {
             Strings gg;
-            for (unsigned mit = 0; mit < mesh_conn[git].size(); ++mit) {
+            for (unsigned mit = 0; mit < mesh_conn[git].size(); ++mit)
                 gg.push_back(meshes()[mesh_conn[git][mit]].name());
-            }
             geo_group_.push_back(gg);
         }
 

--- a/OpenMEEG/libs/OpenMEEG/src/interface.cpp
+++ b/OpenMEEG/libs/OpenMEEG/src/interface.cpp
@@ -54,7 +54,7 @@ namespace OpenMEEG {
             std::cerr << "Interface::contains_point(" << p << ") Error. This should not happen. Are you sure the mesh is properly oriented ?\n";
             return true;
         } else {
-            std::cerr << "Interface::contains_point(" << p << ") Error. Are you sure the interface \"" << name_ << "\" is closed? Solid angle: " << std::abs(solangle)/M_PI <<"*PI." << std::endl;
+            std::cerr << "Interface::contains_point(" << p << ") Error. Are you sure the interface \"" << name() << "\" is closed? Solid angle: " << std::abs(solangle)/M_PI <<"*PI." << std::endl;
             return std::abs(solangle)>2*M_PI?true:false;
         }
     }
@@ -112,7 +112,7 @@ namespace OpenMEEG {
         //if the bounding box center is not inside the interface,
         //we try to test another point inside the bounding box.
         if ( almost_equal(solangle, 0.)) {
-            //std::cout<<"bbcenter is not inside interface: "<<name_<<std::endl;
+            //std::cout << "bbcenter is not inside interface: " << name() << std::endl;
             if ( not checked)
                 std::srand((unsigned int)std::time(NULL));
             else

--- a/OpenMEEG/src/assemble.cpp
+++ b/OpenMEEG/src/assemble.cpp
@@ -64,18 +64,18 @@ int main(int argc, char** argv)
     print_version(argv[0]);
 
     bool OLD_ORDERING = false;
-    if ( argc<2 ) {
+    if (argc<2) {
         getHelp(argv);
         return 0;
     } else {
         OLD_ORDERING = (strcmp(argv[argc-1], "-old-ordering") == 0);
-        if ( OLD_ORDERING ) {
+        if (OLD_ORDERING) {
             argc--;
             cout << "Using old ordering i.e using (V1, p1, V2, p2, V3) instead of (V1, V2, V3, p1, p2)" << endl;
         }
     }
 
-    if ( option(argc, argv, {"-h","--help"}, {})) getHelp(argv);
+    if (option(argc, argv, {"-h","--help"}, {})) getHelp(argv);
 
     disp_argv(argc, argv);
 
@@ -86,14 +86,14 @@ int main(int argc, char** argv)
     /*********************************************************************************************
     * Computation of Head Matrix for BEM Symmetric formulation
     **********************************************************************************************/
-    if ( option(argc, argv, {"-HeadMat","-HM", "-hm"},
-                {"geometry file", "conductivity file", "output file"}) ) {
+    if (option(argc, argv, {"-HeadMat","-HM", "-hm"},
+                {"geometry file", "conductivity file", "output file"})) {
         // Loading surfaces from geometry file
         Geometry geo;
         geo.read(argv[2], argv[3], OLD_ORDERING);
 
         // Check for intersecting meshes
-        if ( !geo.selfCheck() ) {
+        if (!geo.selfCheck()) {
             exit(1);
         }
 
@@ -105,27 +105,27 @@ int main(int argc, char** argv)
     /*********************************************************************************************
     * Computation of Cortical Matrix for BEM Symmetric formulation
     **********************************************************************************************/
-    else if ( option(argc, argv, {"-CorticalMat", "-CM", "-cm"},
-                     {"geometry file", "conductivity file", "sensors file", "domain name", "output file"}) ) {
+    else if (option(argc, argv, {"-CorticalMat", "-CM", "-cm"},
+                     {"geometry file", "conductivity file", "sensors file", "domain name", "output file"})) {
         double alpha = -1., beta = -1, gamma = -1.;
         string filename = "";
 
         switch (argc) {
         case 8: { // case gamma or filename
             stringstream ss(argv[7]);
-            if ( !(ss >> gamma) ) {
+            if (!(ss >> gamma)) {
                 filename.append(argv[7]);
             }
             break;
                 }
         case 9:{ // case alpha+beta or gamma+filename
             stringstream ss(argv[7]);
-            if ( !(ss >> alpha) ) {
+            if (!(ss >> alpha)) {
                 throw runtime_error("given parameter is not a number");
             }
             ss.str(argv[8]);
             ss.clear();
-            if ( !(ss >> beta) ) {
+            if (!(ss >> beta)) {
                 filename.append(argv[8]);
                 gamma = alpha;
             }
@@ -133,12 +133,12 @@ int main(int argc, char** argv)
                 }
         case 10:{ // case alpha+beta + filename
             stringstream ss(argv[7]);
-            if ( !(ss >> alpha) ) {
+            if (!(ss >> alpha)) {
                 throw runtime_error("given parameter is not a number");
             }
             ss.str(argv[8]);
             ss.clear();
-            if ( !(ss >> beta) ) {
+            if (!(ss >> beta)) {
                 throw runtime_error("given parameter is not a number");
             }
             filename.append(argv[9]);
@@ -151,7 +151,7 @@ int main(int argc, char** argv)
         geo.read(argv[2], argv[3], OLD_ORDERING);
 
         // Check for intersecting meshes
-        if ( !geo.selfCheck() ) {
+        if (!geo.selfCheck()) {
             exit(1);
         }
 
@@ -172,7 +172,7 @@ int main(int argc, char** argv)
     /*********************************************************************************************
     * Computation of general Surface Source Matrix for BEM Symmetric formulation
     **********************************************************************************************/
-    else if ( option(argc, argv, {"-SurfSourceMat", "-SSM", "-ssm"},
+    else if (option(argc, argv, {"-SurfSourceMat", "-SSM", "-ssm"},
                      {"geometry file", "conductivity file", "'mesh of sources' file", "output file"})) {
 
         // Loading surfaces from geometry file.
@@ -191,11 +191,11 @@ int main(int argc, char** argv)
     /*********************************************************************************************
     * Computation of RHS for discrete dipolar case
     **********************************************************************************************/
-    else if ( option(argc, argv, {"-DipSourceMat", "-DSM", "-dsm", "-DipSourceMatNoAdapt", "-DSMNA", "-dsmna"},
-                     {"geometry file", "conductivity file", "dipoles file", "output file"}) ) {
+    else if (option(argc, argv, {"-DipSourceMat", "-DSM", "-dsm", "-DipSourceMatNoAdapt", "-DSMNA", "-dsmna"},
+                     {"geometry file", "conductivity file", "dipoles file", "output file"})) {
 
         string domain_name = "";
-        if ( argc == 7 ) {
+        if (argc == 7) {
             domain_name = argv[6];
             cout << "Dipoles are considered to be in \"" << domain_name << "\" domain." << endl;
         }
@@ -206,7 +206,7 @@ int main(int argc, char** argv)
 
         // Loading Matrix of dipoles :
         Matrix dipoles(argv[4]);
-        if ( dipoles.ncol() != 6 ) {
+        if (dipoles.ncol() != 6) {
             cerr << "Dipoles File Format Error" << endl;
             exit(1);
         }
@@ -214,7 +214,7 @@ int main(int argc, char** argv)
         bool adapt_rhs = true;
 
         // Choosing between adaptive integration or not for the RHS
-        if ( option(argc, argv, {"-DipSourceMatNoAdapt", "-DSMNA", "-dsmna"},
+        if (option(argc, argv, {"-DipSourceMatNoAdapt", "-DSMNA", "-dsmna"},
                     {"geometry file", "conductivity file", "dipoles file", "output file"})) {
             adapt_rhs = false;
         }
@@ -228,8 +228,8 @@ int main(int argc, char** argv)
     * Computation of the RHS for EIT
     **********************************************************************************************/
 
-    else if ( option(argc, argv, {"-EITSourceMat", "-EITSM", "-EITsm"},
-                     {"geometry file", "conductivity file", "electrodes positions file", "output file"}) ) {
+    else if (option(argc, argv, {"-EITSourceMat", "-EITSM", "-EITsm"},
+                     {"geometry file", "conductivity file", "electrodes positions file", "output file"})) {
 
         // Loading surfaces from geometry file.
         Geometry geo;
@@ -246,8 +246,8 @@ int main(int argc, char** argv)
     * (i.e. the potential and the normal current on all interfaces)
     * |----> v (potential at the electrodes)
     **********************************************************************************************/
-    else if ( option(argc, argv, {"-Head2EEGMat", "-H2EM", "-h2em"},
-                     {"geometry file", "conductivity file", "electrodes positions file", "output file"}) ) {
+    else if (option(argc, argv, {"-Head2EEGMat", "-H2EM", "-h2em"},
+                     {"geometry file", "conductivity file", "electrodes positions file", "output file"})) {
 
         // Loading surfaces from geometry file.
         Geometry geo;
@@ -268,25 +268,49 @@ int main(int argc, char** argv)
     * (i.e. the potential and the normal current on all interfaces)
     * |----> v (potential at the ECoG electrodes)
     **********************************************************************************************/
-    else if ( option(argc, argv, {"-Head2ECoGMat", "-H2ECogM", "-H2ECOGM", "-h2ecogm"},
-                     {"geometry file", "conductivity file", "ECoG electrodes positions file",
-                      "the name of the interface for EcoG", "output file"}) ) {
+    else if (argc==6 && option(argc, argv, {"-Head2ECoGMat", "-H2ECogM", "-H2ECOGM", "-h2ecogm"},
+                                            {"geometry file", "conductivity file", "ECoG electrodes positions file", "output file"})) {
 
         // Loading surfaces from geometry file.
+
         Geometry geo;
         geo.read(argv[2], argv[3], OLD_ORDERING);
 
-        // Find the mesh of the ECoG electrodes
-        const Interface &i = geo.interface(argv[5]);
+        // Reading the file containing the positions of the EEG patches
 
-        // read the file containing the positions of the EEG patches
         Sensors electrodes(argv[4]);
 
-        // Assembling Matrix from discretization :
+        // Assembling Matrix from discretization:
         // Head2ECoG is the linear application which maps x |----> v
-        Head2ECoGMat mat(geo, electrodes, i);
 
-        // Saving Head2ECoG Matrix :
+        std::cerr << "Warning: we assume that ECoG electrodes are placed on the inner interface." << std::endl
+                  << "This is only valid for nested files. Consider specifying an interface as a name" << std::endl
+                  << " right after the electrode position file." << std::endl;
+        const Interface& innerSkullLayer = geo.innermost_interface();
+        std::cerr << "Detected interface: " << innerSkullLayer.name() << ' ' << geo.interface("3").name() << std::endl;
+        Head2ECoGMat mat(geo,electrodes,innerSkullLayer);
+        mat.save(argv[5]);
+    }
+    else if (option(argc, argv, {"-Head2ECoGMat", "-H2ECogM", "-H2ECOGM", "-h2ecogm"},
+                     {"geometry file", "conductivity file", "ECoG electrodes positions file",
+                      "name of the interface for EcoG", "output file"})) {
+
+        // Loading surfaces from geometry file.
+
+        Geometry geo;
+        geo.read(argv[2], argv[3], OLD_ORDERING);
+
+        // Reading the file containing the positions of the EEG patches
+
+        Sensors electrodes(argv[4]);
+
+        // Assembling Matrix from discretization:
+        // Head2ECoG is the linear application which maps x |----> v
+
+        // Find the mesh of the ECoG electrodes
+
+        const Interface& index = geo.interface(argv[5]);
+        Head2ECoGMat mat(geo,electrodes,index);
         mat.save(argv[6]);
     }
 
@@ -295,8 +319,8 @@ int main(int argc, char** argv)
     * (i.e. the potential and the normal current on all interfaces)
     * |----> bFerguson (contrib to MEG response)
     **********************************************************************************************/
-    else if ( option(argc, argv, {"-Head2MEGMat", "-H2MM", "-h2mm"},
-                     {"geometry file", "conductivity file", "squids file", "output file"}) ) {
+    else if (option(argc, argv, {"-Head2MEGMat", "-H2MM", "-h2mm"},
+                     {"geometry file", "conductivity file", "squids file", "output file"})) {
 
         // Loading surfaces from geometry file.
         Geometry geo;
@@ -315,8 +339,8 @@ int main(int argc, char** argv)
     * Computation of the linear application which maps the distributed source
     * |----> binf (contrib to MEG response)
     **********************************************************************************************/
-    else if ( option(argc, argv, {"-SurfSource2MEGMat", "-SS2MM", "-ss2mm"},
-                     {"'mesh sources' file", "squids file", "output file"}) ) {
+    else if (option(argc, argv, {"-SurfSource2MEGMat", "-SS2MM", "-ss2mm"},
+                     {"'mesh sources' file", "squids file", "output file"})) {
 
         // Loading mesh for distributed sources :
         Mesh mesh_sources;
@@ -337,8 +361,8 @@ int main(int argc, char** argv)
     // arguments are the positions and orientations of the squids,
     // the position and orientations of the sources and the output name.
 
-    else if ( option(argc, argv, {"-DipSource2MEGMat", "-DS2MM", "-ds2mm"},
-                     {"dipoles file", "squids file", "output file"}) ) {
+    else if (option(argc, argv, {"-DipSource2MEGMat", "-DS2MM", "-ds2mm"},
+                     {"dipoles file", "squids file", "output file"})) {
 
         // Loading dipoles :
         Matrix dipoles(argv[2]);
@@ -346,7 +370,7 @@ int main(int argc, char** argv)
         // Load positions and orientations of sensors  :
         Sensors sensors(argv[3]);
 
-        DipSource2MEGMat mat( dipoles, sensors );
+        DipSource2MEGMat mat(dipoles, sensors);
         mat.save(argv[4]);
     }
 
@@ -355,8 +379,8 @@ int main(int argc, char** argv)
     * |----> v, potential at a set of prescribed points within the 3D volume
     **********************************************************************************************/
 
-    else if ( option(argc, argv, {"-Head2InternalPotMat", "-H2IPM", "-h2ipm"},
-                     {"geometry file", "conductivity file", "point positions file", "output file"}) ) {
+    else if (option(argc, argv, {"-Head2InternalPotMat", "-H2IPM", "-h2ipm"},
+                     {"geometry file", "conductivity file", "point positions file", "output file"})) {
 
         // Loading surfaces from geometry file
         Geometry geo;
@@ -372,7 +396,7 @@ int main(int argc, char** argv)
     *    Vinf(r)=1/(4*pi*sigma)*(r-r0).q/(||r-r0||^3)
     **********************************************************************************************/
 
-    else if ( option(argc, argv, {"-DipSource2InternalPotMat", "-DS2IPM", "-ds2ipm"},
+    else if (option(argc, argv, {"-DipSource2InternalPotMat", "-DS2IPM", "-ds2ipm"},
                      {"geometry file", "conductivity file", "dipole file", "point positions file", "output file"})) {
         string domain_name = "";
         if (argc==9) {
@@ -399,11 +423,11 @@ int main(int argc, char** argv)
 }
 
 bool option(const int argc, char ** argv, const Strings& options, const Strings& files) {
-    for ( auto s: options) {
+    for (auto s: options) {
         if (argv[1] == s) {
             if (argc-2 < files.size()) {
                 cout << "\'om_assemble\' option \'" << argv[1] << "\' expects " << files.size() << " arguments (";
-                for ( auto f: files) {
+                for (auto f: files) {
                     cout << f;
                     if (f != files[files.size() - 1]){
                         cout << ", ";

--- a/OpenMEEG/wrapping/src/doxy2swig.py
+++ b/OpenMEEG/wrapping/src/doxy2swig.py
@@ -1,25 +1,23 @@
 #!/usr/bin/env python
-"""Doxygen XML to SWIG docstring converter.
+"""doxy2swig.py [options] index.xml output.i
 
-Usage:
-
-  doxy2swig.py [options] input.xml output.i
+Doxygen XML to SWIG docstring converter (improved version).
 
 Converts Doxygen generated XML files into a file containing docstrings
-that can be used by SWIG-1.3.x.  Note that you need to get SWIG
-version > 1.3.23 or use Robin Dunn's docstring patch to be able to use
-the resulting output.
+for use by SWIG.
 
-input.xml is your doxygen generated XML file and output.i is where the
+index.xml is your doxygen generated XML file and output.i is where the
 output will be written (the file will be clobbered).
-
 """
-######################################################################
+#
+# The current version of this code is hosted on a github repository:
+#   https://github.com/m7thon/doxy2swig
 #
 # This code is implemented using Mark Pilgrim's code as a guideline:
 #   http://www.faqs.org/docs/diveintopython/kgp_divein.html
 #
-# Author: Prabhu Ramachandran
+# Original Author: Prabhu Ramachandran
+# Modified by:     Michael Thon (June 2015)
 # License: BSD style
 #
 # Thanks:
@@ -27,7 +25,25 @@ output will be written (the file will be clobbered).
 #   Bill Spotz:  bug reports and testing.
 #   Sebastian Henschel:   Misc. enhancements.
 #
-######################################################################
+# Changes:
+# June 2015 (Michael Thon):
+#   - class documentation:
+#     -c: add constructor call signatures and a "Constructors" section
+#         collecting the respective docs (e.g. for python)
+#     -a: add "Attributes" section collecting the documentation for member
+#         variables (e.g. for python)
+#   - overloaded functions:
+#     -o: collect all documentation into one "Overloaded function" section
+#   - option to include function definition / signature renamed to -f
+#   - formatting:
+#     + included function signatures slightly reformatted
+#     + option (-t) to turn off/on type information for funciton signatures
+#     + lists (incl. nested and ordered)
+#     + attempt to produce docstrings that render nicely as markdown
+#     + translate code, emphasis, bold, linebreak, hruler, blockquote,
+#       verbatim, heading tags to markdown
+#     + new text-wrapping and option -w to specify the text width
+#
 
 from xml.dom import minidom
 import re
@@ -41,24 +57,61 @@ def my_open_read(source):
     if hasattr(source, "read"):
         return source
     else:
-        return open(source)
+        try:
+            return open(source, encoding='utf-8')
+        except TypeError:
+            return open(source)
 
 def my_open_write(dest):
     if hasattr(dest, "write"):
         return dest
     else:
-        return open(dest, 'wb')
+        try:
+            return open(dest, 'w', encoding='utf-8')
+        except TypeError:
+            return open(dest, 'w')
 
+# MARK: Text handling:
+def shift(txt, indent = '    ', prepend = ''):
+    """Return a list corresponding to the lines of text in the `txt` list
+    indented by `indent`. Prepend instead the string given in `prepend` to the
+    beginning of the first line. Note that if len(prepend) > len(indent), then
+    `prepend` will be truncated (doing better is tricky!). This preserves a 
+    special '' entry at the end of `txt` (see `do_para` for the meaning).
+    """
+    if type(indent) is int:
+        indent = indent * ' '
+    special_end = txt[-1:] == ['']
+    lines = ''.join(txt).splitlines(True)
+    for i in range(1,len(lines)):
+        if lines[i].strip() or indent.strip():
+            lines[i] = indent + lines[i]
+    if not lines:
+        return prepend
+    prepend = prepend[:len(indent)]
+    indent = indent[len(prepend):]
+    lines[0] = prepend + indent + lines[0]
+    ret = [''.join(lines)]
+    if special_end:
+        ret.append('')
+    return ret
 
-class Doxy2SWIG:    
+class Doxy2SWIG:
     """Converts Doxygen generated XML files into a file containing
     docstrings that can be used by SWIG-1.3.x that have support for
     feature("docstring").  Once the data is parsed it is stored in
     self.pieces.
 
-    """    
-    
-    def __init__(self, src, include_function_definition=True, quiet=False):
+    """
+
+    def __init__(self, src,
+                 with_function_signature = False,
+                 with_type_info = False,
+                 with_constructor_list = False,
+                 with_attribute_list = False,
+                 with_overloaded_functions = False,
+                 textwidth = 80,
+                 quiet = False):
         """Initialize the instance given a source object.  `src` can
         be a file or filename.  If you do not want to include function
         definitions from doxygen then set
@@ -67,13 +120,26 @@ class Doxy2SWIG:
         using %feature("autodoc", [0,1]).
 
         """
+        # options:
+        self.with_function_signature = with_function_signature
+        self.with_type_info = with_type_info
+        self.with_constructor_list = with_constructor_list
+        self.with_attribute_list = with_attribute_list
+        self.with_overloaded_functions = with_overloaded_functions
+        self.textwidth = textwidth
+        self.quiet = quiet
+
+        # state:
+        self.indent = 0
+        self.listitem = ''
+        self.pieces = []
+
         f = my_open_read(src)
         self.my_dir = os.path.dirname(f.name)
         self.xmldoc = minidom.parse(f).documentElement
         f.close()
 
-        self.pieces = []
-        self.pieces.append('\n// File: %s\n'%\
+        self.pieces.append('\n// File: %s\n' %
                            os.path.basename(f.name))
 
         self.space_re = re.compile(r'\s+')
@@ -85,29 +151,30 @@ class Doxy2SWIG:
                         'references', 'referencedby', 'location',
                         'collaborationgraph', 'reimplements',
                         'reimplementedby', 'derivedcompoundref',
-                        'basecompoundref']
+                        'basecompoundref',
+                        'argsstring', 'definition', 'exceptions']
         #self.generics = []
-        self.include_function_definition = include_function_definition
-        if not include_function_definition:
-            self.ignores.append('argsstring')
 
-        self.quiet = quiet
-            
-        
     def generate(self):
         """Parses the file set in the initialization.  The resulting
         data is stored in `self.pieces`.
 
         """
         self.parse(self.xmldoc)
-    
+
+    def write(self, fname):
+        o = my_open_write(fname)
+        o.write(''.join(self.pieces))
+        o.write('\n')
+        o.close()
+
     def parse(self, node):
         """Parse a given node.  This function in turn calls the
         `parse_<nodeType>` functions which handle the respective
         nodes.
 
         """
-        pm = getattr(self, "parse_%s"%node.__class__.__name__)
+        pm = getattr(self, "parse_%s" % node.__class__.__name__)
         pm(node)
 
     def parse_Document(self, node):
@@ -115,21 +182,29 @@ class Doxy2SWIG:
 
     def parse_Text(self, node):
         txt = node.data
-        txt = txt.replace('\\', r'\\\\')
+        if txt == ' ':
+            # this can happen when two tags follow in a text, e.g.,
+            # " ...</emph> <formaula>$..." etc.
+            # here we want to keep the space.
+            self.add_text(txt)
+            return
+        txt = txt.replace('\\', r'\\')
         txt = txt.replace('"', r'\"')
         # ignore pure whitespace
         m = self.space_re.match(txt)
-        if m and len(m.group()) == len(txt):
-            pass
-        else:
-            self.add_text(textwrap.fill(txt, break_long_words=False))
+        if not (m and len(m.group()) == len(txt)):
+            self.add_text(txt)
+
+    def parse_Comment(self, node):
+        """Parse a `COMMENT_NODE`.  This does nothing for now."""
+        return
 
     def parse_Element(self, node):
         """Parse an `ELEMENT_NODE`.  This calls specific
         `do_<tagName>` handers for different elements.  If no handler
-        is available the `generic_parse` method is called.  All
+        is available the `subnode_parse` method is called.  All
         tagNames specified in `self.ignores` are simply ignored.
-        
+
         """
         name = node.tagName
         ignores = self.ignores
@@ -140,12 +215,73 @@ class Doxy2SWIG:
             handlerMethod = getattr(self, attr)
             handlerMethod(node)
         else:
-            self.generic_parse(node)
+            self.subnode_parse(node)
             #if name not in self.generics: self.generics.append(name)
 
-    def parse_Comment(self, node):
-        """Parse a `COMMENT_NODE`.  This does nothing for now."""
-        return
+# MARK: Special format parsing
+    def subnode_parse(self, node, pieces=None, indent=0, ignore=[], restrict=None):
+        """Parse the subnodes of a given node. Subnodes with tags in the
+        `ignore` list are ignored. If pieces is given, use this as target for
+        the parse results instead of self.pieces. Indent all lines by the amount
+        given in `indent`. Note that the initial content in `pieces` is not
+        indented. The final result is in any case added to self.pieces."""
+        if pieces is not None:
+            old_pieces, self.pieces = self.pieces, pieces
+        else:
+            old_pieces = []
+        if type(indent) is int:
+            indent = indent * ' '
+        if len(indent) > 0:
+            pieces = ''.join(self.pieces)
+            i_piece = pieces[:len(indent)]
+            if self.pieces[-1:] == ['']:
+                self.pieces = [pieces[len(indent):]] + ['']
+            elif self.pieces != []:
+                self.pieces = [pieces[len(indent):]]
+        self.indent += len(indent)
+        for n in node.childNodes:
+            if restrict is not None:
+                if n.nodeType == n.ELEMENT_NODE and n.tagName in restrict:
+                    self.parse(n)
+            elif n.nodeType != n.ELEMENT_NODE or n.tagName not in ignore:
+                self.parse(n)
+        if len(indent) > 0:
+            self.pieces = shift(self.pieces, indent, i_piece)
+        self.indent -= len(indent)
+        old_pieces.extend(self.pieces)
+        self.pieces = old_pieces
+
+    def surround_parse(self, node, pre_char, post_char):
+        """Parse the subnodes of a given node. Subnodes with tags in the
+        `ignore` list are ignored. Prepend `pre_char` and append `post_char` to
+        the output in self.pieces."""
+        self.add_text(pre_char)
+        self.subnode_parse(node)
+        self.add_text(post_char)
+    
+# MARK: Helper functions
+    def get_specific_subnodes(self, node, name, recursive=0):
+        """Given a node and a name, return a list of child `ELEMENT_NODEs`, that
+        have a `tagName` matching the `name`. Search recursively for `recursive`
+        levels.
+        """
+        children = [x for x in node.childNodes if x.nodeType == x.ELEMENT_NODE]
+        ret = [x for x in children if x.tagName == name]
+        if recursive > 0:
+            for x in children:
+                ret.extend(self.get_specific_subnodes(x, name, recursive-1))
+        return ret
+
+    def get_specific_nodes(self, node, names):
+        """Given a node and a sequence of strings in `names`, return a
+        dictionary containing the names as keys and child
+        `ELEMENT_NODEs`, that have a `tagName` equal to the name.
+
+        """
+        nodes = [(x.tagName, x) for x in node.childNodes
+                 if x.nodeType == x.ELEMENT_NODE and
+                 x.tagName in names]
+        return dict(nodes)
 
     def add_text(self, value):
         """Adds text corresponding to `value` into `self.pieces`."""
@@ -154,214 +290,473 @@ class Doxy2SWIG:
         else:
             self.pieces.append(value)
 
-    def get_specific_nodes(self, node, names):
-        """Given a node and a sequence of strings in `names`, return a
-        dictionary containing the names as keys and child
-        `ELEMENT_NODEs`, that have a `tagName` equal to the name.
-
+    def start_new_paragraph(self):
+        """Make sure to create an empty line. This is overridden, if the previous
+        text ends with the special marker ''. In that case, nothing is done.
         """
-        nodes = [(x.tagName, x) for x in node.childNodes \
-                 if x.nodeType == x.ELEMENT_NODE and \
-                 x.tagName in names]
-        return dict(nodes)
+        if self.pieces[-1:] == ['']: # respect special marker
+            return
+        elif self.pieces == []: # first paragraph, add '\n', override with ''
+            self.pieces = ['\n']
+        elif self.pieces[-1][-1:] != '\n': # previous line not ended
+            self.pieces.extend(['  \n' ,'\n'])
+        else: #default
+            self.pieces.append('\n')
 
-    def generic_parse(self, node, pad=0):
-        """A Generic parser for arbitrary tags in a node.
-
-        Parameters:
-
-         - node:  A node in the DOM.
-         - pad: `int` (default: 0)
-
-           If 0 the node data is not padded with newlines.  If 1 it
-           appends a newline after parsing the childNodes.  If 2 it
-           pads before and after the nodes are processed.  Defaults to
-           0.
-
+    def add_line_with_subsequent_indent(self, line, indent=4):
+        """Add line of text and wrap such that subsequent lines are indented
+        by `indent` spaces.
         """
-        npiece = 0
-        if pad:
-            npiece = len(self.pieces)
-            if pad == 2:
-                self.add_text('\n')                
-        for n in node.childNodes:
-            self.parse(n)
-        if pad:
-            if len(self.pieces) > npiece:
-                self.add_text('\n')
+        if isinstance(line, (list, tuple)):
+            line = ''.join(line)
+        line = line.strip()
+        width = self.textwidth-self.indent-indent
+        wrapped_lines = textwrap.wrap(line[indent:], width=width)
+        for i in range(len(wrapped_lines)):
+            if wrapped_lines[i] != '':
+                wrapped_lines[i] = indent * ' ' + wrapped_lines[i]
+        self.pieces.append(line[:indent] + '\n'.join(wrapped_lines)[indent:] + '  \n')
 
-    def space_parse(self, node):
-        self.add_text(' ')
-        self.generic_parse(node)
+    def extract_text(self, node):
+        """Return the string representation of the node or list of nodes by parsing the
+        subnodes, but returning the result as a string instead of adding it to `self.pieces`.
+        Note that this allows extracting text even if the node is in the ignore list.
+        """
+        if not isinstance(node, (list, tuple)):
+            node = [node]
+        pieces, self.pieces = self.pieces, ['']
+        for n in node:
+            for sn in n.childNodes:
+                self.parse(sn)
+        ret = ''.join(self.pieces)
+        self.pieces = pieces
+        return ret
 
-    do_ref = space_parse
-    do_emphasis = space_parse
-    do_bold = space_parse
-    do_computeroutput = space_parse
-    do_formula = space_parse
+    def get_function_signature(self, node):
+        """Returns the function signature string for memberdef nodes."""
+        name = self.extract_text(self.get_specific_subnodes(node, 'name'))
+        if self.with_type_info:
+            argsstring = self.extract_text(self.get_specific_subnodes(node, 'argsstring'))
+        else:
+            argsstring = []
+            param_id = 1
+            for n_param in self.get_specific_subnodes(node, 'param'):
+                declname = self.extract_text(self.get_specific_subnodes(n_param, 'declname'))
+                if not declname:
+                    declname = 'arg' + str(param_id)
+                defval = self.extract_text(self.get_specific_subnodes(n_param, 'defval'))
+                if defval:
+                    defval = '=' + defval
+                argsstring.append(declname + defval)
+                param_id = param_id + 1
+            argsstring = '(' + ', '.join(argsstring) + ')'
+        type = self.extract_text(self.get_specific_subnodes(node, 'type'))
+        function_definition = name + argsstring
+        if type != '' and type != 'void':
+            function_definition = function_definition + ' -> ' + type
+        return '`' + function_definition + '`  '
 
-    def do_compoundname(self, node):
-        self.add_text('\n\n')
-        data = node.firstChild.data
-        self.add_text('%%feature("docstring") %s "\n'%data)
+# MARK: Special parsing tasks (need to be called manually)
+    def make_constructor_list(self, constructor_nodes, classname):
+        """Produces the "Constructors" section and the constructor signatures
+        (since swig does not do so for classes) for class docstrings."""
+        if constructor_nodes == []:
+            return
+        self.add_text(['\n', 'Constructors',
+                       '\n', '------------'])
+        for n in constructor_nodes:
+            self.add_text('\n')
+            self.add_line_with_subsequent_indent('* ' + self.get_function_signature(n))
+            self.subnode_parse(n, pieces = [], indent=4, ignore=['definition', 'name'])
 
+    def make_attribute_list(self, node):
+        """Produces the "Attributes" section in class docstrings for public
+        member variables (attributes).
+        """
+        atr_nodes = []
+        for n in self.get_specific_subnodes(node, 'memberdef', recursive=2):
+            if n.attributes['kind'].value == 'variable' and n.attributes['prot'].value == 'public':
+                atr_nodes.append(n)
+        if not atr_nodes:
+            return
+        self.add_text(['\n', 'Attributes',
+                       '\n', '----------'])
+        for n in atr_nodes:
+            name = self.extract_text(self.get_specific_subnodes(n, 'name'))
+            self.add_text(['\n* ', '`', name, '`', ' : '])
+            self.add_text(['`', self.extract_text(self.get_specific_subnodes(n, 'type')), '`'])
+            self.add_text('  \n')
+            restrict = ['briefdescription', 'detaileddescription']
+            self.subnode_parse(n, pieces=[''], indent=4, restrict=restrict)
+
+    def get_memberdef_nodes_and_signatures(self, node, kind):
+        """Collects the memberdef nodes and corresponding signatures that
+        correspond to public function entries that are at most depth 2 deeper
+        than the current (compounddef) node. Returns a dictionary with 
+        function signatures (what swig expects after the %feature directive)
+        as keys, and a list of corresponding memberdef nodes as values."""
+        sig_dict = {}
+        sig_prefix = ''
+        if kind in ('file', 'namespace'):
+            ns_node = node.getElementsByTagName('innernamespace')
+            if not ns_node and kind == 'namespace':
+                ns_node = node.getElementsByTagName('compoundname')
+            if ns_node:
+                sig_prefix = self.extract_text(ns_node[0]) + '::'
+        elif kind in ('class', 'struct'):
+            # Get the full function name.
+            cn_node = node.getElementsByTagName('compoundname')
+            sig_prefix = self.extract_text(cn_node[0]) + '::'
+
+        md_nodes = self.get_specific_subnodes(node, 'memberdef', recursive=2)
+        for n in md_nodes:
+            if n.attributes['prot'].value != 'public':
+                continue
+            if n.attributes['kind'].value in ['variable', 'typedef']:
+                continue
+            if not self.get_specific_subnodes(n, 'definition'):
+                continue
+            name = self.extract_text(self.get_specific_subnodes(n, 'name'))
+            if name[:8] == 'operator':
+                continue
+            sig = sig_prefix + name
+            if sig in sig_dict:
+                sig_dict[sig].append(n)
+            else:
+                sig_dict[sig] = [n]
+        return sig_dict
+    
+    def handle_typical_memberdefs_no_overload(self, signature, memberdef_nodes):
+        """Produce standard documentation for memberdef_nodes."""
+        for n in memberdef_nodes:
+            self.add_text(['\n', '%feature("docstring") ', signature, ' "', '\n'])
+            if self.with_function_signature:
+                self.add_line_with_subsequent_indent(self.get_function_signature(n))
+            self.subnode_parse(n, pieces=[], ignore=['definition', 'name'])
+            self.add_text(['";', '\n'])
+
+    def handle_typical_memberdefs(self, signature, memberdef_nodes):
+        """Produces docstring entries containing an "Overloaded function"
+        section with the documentation for each overload, if the function is
+        overloaded and self.with_overloaded_functions is set. Else, produce
+        normal documentation.
+        """
+        if len(memberdef_nodes) == 1 or not self.with_overloaded_functions:
+            self.handle_typical_memberdefs_no_overload(signature, memberdef_nodes)
+            return
+
+        self.add_text(['\n', '%feature("docstring") ', signature, ' "', '\n'])
+        if self.with_function_signature:
+            for n in memberdef_nodes:
+                self.add_line_with_subsequent_indent(self.get_function_signature(n))
+        self.add_text('\n')
+        self.add_text(['Overloaded function', '\n',
+                       '-------------------'])
+        for n in memberdef_nodes:
+            self.add_text('\n')
+            self.add_line_with_subsequent_indent('* ' + self.get_function_signature(n))
+            self.subnode_parse(n, pieces=[], indent=4, ignore=['definition', 'name'])
+        self.add_text(['";', '\n'])
+    
+
+# MARK: Tag handlers
+    def do_linebreak(self, node):
+        self.add_text('  ')
+    
+    def do_ndash(self, node):
+        self.add_text('--')
+
+    def do_mdash(self, node):
+        self.add_text('---')
+
+    def do_emphasis(self, node):
+        self.surround_parse(node, '*', '*')
+
+    def do_bold(self, node):
+        self.surround_parse(node, '**', '**')
+    
+    def do_computeroutput(self, node):
+        self.surround_parse(node, '`', '`')
+
+    def do_heading(self, node):
+        self.start_new_paragraph()
+        pieces, self.pieces = self.pieces, ['']
+        level = int(node.attributes['level'].value)
+        self.subnode_parse(node)
+        if level == 1:
+            self.pieces.insert(0, '\n')
+            self.add_text(['\n', len(''.join(self.pieces).strip()) * '='])
+        elif level == 2:
+            self.add_text(['\n', len(''.join(self.pieces).strip()) * '-'])
+        elif level >= 3:
+            self.pieces.insert(0, level * '#' + ' ')
+        # make following text have no gap to the heading:
+        pieces.extend([''.join(self.pieces) + '  \n', ''])
+        self.pieces = pieces
+    
+    def do_verbatim(self, node):
+        self.start_new_paragraph()
+        self.subnode_parse(node, pieces=[''], indent=4)
+    
+    def do_blockquote(self, node):
+        self.start_new_paragraph()
+        self.subnode_parse(node, pieces=[''], indent='> ')
+    
+    def do_hruler(self, node):
+        self.start_new_paragraph()
+        self.add_text('* * * * *  \n')
+    
+    def do_includes(self, node):
+        self.add_text('\nC++ includes: ')
+        self.subnode_parse(node)
+        self.add_text('\n')
+
+# MARK: Para tag handler
+    def do_para(self, node):
+        """This is the only place where text wrapping is automatically performed.
+        Generally, this function parses the node (locally), wraps the text, and
+        then adds the result to self.pieces. However, it may be convenient to
+        allow the previous content of self.pieces to be included in the text
+        wrapping. For this, use the following *convention*:
+        If self.pieces ends with '', treat the _previous_ entry as part of the
+        current paragraph. Else, insert new-line and start a new paragraph
+        and "wrapping context".
+        Paragraphs always end with '  \n', but if the parsed content ends with
+        the special symbol '', this is passed on.
+        """
+        if self.pieces[-1:] == ['']:
+            pieces, self.pieces = self.pieces[:-2], self.pieces[-2:-1]
+        else:
+            self.add_text('\n')
+            pieces, self.pieces = self.pieces, ['']
+        self.subnode_parse(node)
+        dont_end_paragraph = self.pieces[-1:] == ['']
+        # Now do the text wrapping:
+        width = self.textwidth - self.indent
+        wrapped_para = []
+        for line in ''.join(self.pieces).splitlines():
+            keep_markdown_newline = line[-2:] == '  '
+            w_line = textwrap.wrap(line, width=width, break_long_words=False)
+            if w_line == []:
+                w_line = ['']
+            if keep_markdown_newline:
+                w_line[-1] = w_line[-1] + '  '
+            for wl in w_line:
+                wrapped_para.append(wl + '\n')
+        if wrapped_para:
+            if wrapped_para[-1][-3:] != '  \n':
+                wrapped_para[-1] = wrapped_para[-1][:-1] + '  \n'
+            if dont_end_paragraph:
+                wrapped_para.append('')
+        pieces.extend(wrapped_para)
+        self.pieces = pieces
+
+# MARK: List tag handlers
+    def do_itemizedlist(self, node):
+        if self.listitem == '':
+            self.start_new_paragraph()
+        elif self.pieces != [] and self.pieces[-1:] != ['']:
+            self.add_text('\n')
+        listitem = self.listitem
+        if self.listitem in ['*', '-']:
+            self.listitem = '-'
+        else:
+            self.listitem = '*'
+        self.subnode_parse(node)
+        self.listitem = listitem
+
+    def do_orderedlist(self, node):
+        if self.listitem == '':
+            self.start_new_paragraph()
+        elif self.pieces != [] and self.pieces[-1:] != ['']:
+            self.add_text('\n')
+        listitem = self.listitem
+        self.listitem = 0
+        self.subnode_parse(node)
+        self.listitem = listitem
+
+    def do_listitem(self, node):
+        try:
+            self.listitem = int(self.listitem) + 1
+            item = str(self.listitem) + '. '
+        except:
+            item = str(self.listitem) + ' '
+        self.subnode_parse(node, item, indent=4)
+
+# MARK: Parameter list tag handlers
+    def do_parameterlist(self, node):
+        self.start_new_paragraph()
+        text = 'unknown'
+        for key, val in node.attributes.items():
+            if key == 'kind':
+                if val == 'param':
+                    text = 'Parameters'
+                elif val == 'exception':
+                    text = 'Exceptions'
+                elif val == 'retval':
+                    text = 'Returns'
+                else:
+                    text = val
+                break
+        if self.indent == 0:
+            self.add_text([text, '\n', len(text) * '-', '\n'])
+        else:
+            self.add_text([text, ':  \n'])
+        self.subnode_parse(node)
+
+    def do_parameteritem(self, node):
+        self.subnode_parse(node, pieces=['* ', ''])
+
+    def do_parameternamelist(self, node):
+        self.subnode_parse(node)
+        self.add_text([' :', '  \n'])
+    
+    def do_parametername(self, node):
+        if self.pieces != [] and self.pieces != ['* ', '']:
+            self.add_text(', ')
+        data = self.extract_text(node)
+        self.add_text(['`', data, '`'])
+
+    def do_parameterdescription(self, node):
+        self.subnode_parse(node, pieces=[''], indent=4)
+
+# MARK: Section tag handler
+    def do_simplesect(self, node):
+        kind = node.attributes['kind'].value
+        if kind in ('date', 'rcs', 'version'):
+            return
+        self.start_new_paragraph()
+        if kind == 'warning':
+            self.subnode_parse(node, pieces=['**Warning**: ',''], indent=4)
+        elif kind == 'see':
+            self.subnode_parse(node, pieces=['See also: ',''], indent=4)
+        elif kind == 'return':
+            if self.indent == 0:
+                pieces = ['Returns', '\n', len('Returns') * '-', '\n', '']
+            else:
+                pieces = ['Returns:', '\n', '']
+            self.subnode_parse(node, pieces=pieces)
+        else:
+            self.subnode_parse(node, pieces=[kind + ': ',''], indent=4)
+
+# MARK: %feature("docstring") producing tag handlers
     def do_compounddef(self, node):
+        """This produces %feature("docstring") entries for classes, and handles
+        class, namespace and file memberdef entries specially to allow for 
+        overloaded functions. For other cases, passes parsing on to standard
+        handlers (which may produce unexpected results).
+        """
         kind = node.attributes['kind'].value
         if kind in ('class', 'struct'):
             prot = node.attributes['prot'].value
             if prot != 'public':
                 return
-            names = ('compoundname', 'briefdescription',
-                     'detaileddescription', 'includes')
-            first = self.get_specific_nodes(node, names)
-            for n in names:
-                if n not in first:
-                    self.parse(first[n])
-            self.add_text(['";','\n'])
-            for n in node.childNodes:
-                if n not in first.values():
-                    self.parse(n)
+            self.add_text('\n\n')
+            classdefn = self.extract_text(self.get_specific_subnodes(node, 'compoundname'))
+            classname = classdefn.split('::')[-1]
+            self.add_text('%%feature("docstring") %s "\n' % classdefn)
+
+            if self.with_constructor_list:
+                constructor_nodes = []
+                for n in self.get_specific_subnodes(node, 'memberdef', recursive=2):
+                    if n.attributes['prot'].value == 'public':
+                        if self.extract_text(self.get_specific_subnodes(n, 'definition')) == classdefn + '::' + classname:
+                            constructor_nodes.append(n)
+                for n in constructor_nodes:
+                    self.add_line_with_subsequent_indent(self.get_function_signature(n))
+
+            names = ('briefdescription','detaileddescription')
+            sub_dict = self.get_specific_nodes(node, names)
+            for n in ('briefdescription','detaileddescription'):
+                if n in sub_dict:
+                    self.parse(sub_dict[n])
+            if self.with_constructor_list:
+                self.make_constructor_list(constructor_nodes, classname)
+            if self.with_attribute_list:
+                self.make_attribute_list(node)
+
+            sub_list = self.get_specific_subnodes(node, 'includes')
+            if sub_list:
+                self.parse(sub_list[0])
+            self.add_text(['";', '\n'])
+
+            names = ['compoundname', 'briefdescription','detaileddescription', 'includes']
+            self.subnode_parse(node, ignore = names)
+
         elif kind in ('file', 'namespace'):
             nodes = node.getElementsByTagName('sectiondef')
             for n in nodes:
                 self.parse(n)
 
-    def do_includes(self, node):
-        self.add_text('C++ includes: ')
-        self.generic_parse(node, pad=1)
-
-    def do_parameterlist(self, node):
-        text='unknown'
-        for key, val in node.attributes.items():
-            if key == 'kind':
-                if val == 'param': text = 'Parameters'
-                elif val == 'exception': text = 'Exceptions'
-                elif val == 'retval': text = 'Returns'
-                else: text = val
-                break
-        self.add_text(['\n', '\n', text, ':', '\n'])
-        self.generic_parse(node, pad=1)
-
-    def do_para(self, node):
-        self.add_text('\n')
-        self.generic_parse(node, pad=1)
-
-    def do_parametername(self, node):
-        self.add_text('\n')
-        try:
-            data=node.firstChild.data
-        except AttributeError: # perhaps a <ref> tag in it
-            data=node.firstChild.firstChild.data
-        if data.find('Exception') != -1:
-            self.add_text(data)
-        else:
-            self.add_text("%s: "%data)
-
-    def do_parameterdefinition(self, node):
-        self.generic_parse(node, pad=1)
-
-    def do_detaileddescription(self, node):
-        self.generic_parse(node, pad=1)
-
-    def do_briefdescription(self, node):
-        self.generic_parse(node, pad=1)
-
+        # now explicitely handle possibly overloaded member functions.
+        if kind in ['class', 'struct','file', 'namespace']:
+            md_nodes = self.get_memberdef_nodes_and_signatures(node, kind)
+            for sig in md_nodes:
+                self.handle_typical_memberdefs(sig, md_nodes[sig])
+    
     def do_memberdef(self, node):
+        """Handle cases outside of class, struct, file or namespace. These are
+        now dealt with by `handle_overloaded_memberfunction`.
+        Do these even exist???
+        """
         prot = node.attributes['prot'].value
         id = node.attributes['id'].value
         kind = node.attributes['kind'].value
         tmp = node.parentNode.parentNode.parentNode
         compdef = tmp.getElementsByTagName('compounddef')[0]
         cdef_kind = compdef.attributes['kind'].value
-        
-        if prot == 'public':
-            first = self.get_specific_nodes(node, ('definition', 'name'))
-            name = first['name'].firstChild.data
-            if name[:8] == 'operator': # Don't handle operators yet.
-                return
+        if cdef_kind in ('file', 'namespace', 'class', 'struct'):
+            # These cases are now handled by `handle_typical_memberdefs`
+            return
+        if prot != 'public':
+            return
+        first = self.get_specific_nodes(node, ('definition', 'name'))
+        name = self.extract_text(first['name'])
+        if name[:8] == 'operator':  # Don't handle operators yet.
+            return
+        if not 'definition' in first or kind in ['variable', 'typedef']:
+            return
 
-            if not 'definition' in first or \
-                   kind in ['variable', 'typedef']:
-                return
+        data = self.extract_text(first['definition'])
+        self.add_text('\n')
+        self.add_text(['/* where did this entry come from??? */', '\n'])
+        self.add_text('%feature("docstring") %s "\n%s' % (data, data))
 
-            if self.include_function_definition:
-                defn = first['definition'].firstChild.data
-            else:
-                defn = ""
-            self.add_text('\n')
-            self.add_text('%feature("docstring") ')
-            
-            anc = node.parentNode.parentNode
-            if cdef_kind in ('file', 'namespace'):
-                ns_node = anc.getElementsByTagName('innernamespace')
-                if not ns_node and cdef_kind == 'namespace':
-                    ns_node = anc.getElementsByTagName('compoundname')
-                if ns_node:
-                    ns = ns_node[0].firstChild.data
-                    self.add_text(' %s::%s "\n%s'%(ns, name, defn))
-                else:
-                    self.add_text(' %s "\n%s'%(name, defn))
-            elif cdef_kind in ('class', 'struct'):
-                # Get the full function name.
-                anc_node = anc.getElementsByTagName('compoundname')
-                cname = anc_node[0].firstChild.data
-                self.add_text(' %s::%s "\n%s'%(cname, name, defn))
-
-            for n in node.childNodes:
-                if n not in first.values():
-                    self.parse(n)
-            self.add_text(['";', '\n'])
-        
-    def do_definition(self, node):
-        data = node.firstChild.data
-        self.add_text('%s "\n%s'%(data, data))
-
+        for n in node.childNodes:
+            if n not in first.values():
+                self.parse(n)
+        self.add_text(['";', '\n'])
+    
+# MARK: Entry tag handlers (dont print anything meaningful)
     def do_sectiondef(self, node):
         kind = node.attributes['kind'].value
         if kind in ('public-func', 'func', 'user-defined', ''):
-            self.generic_parse(node)
+            self.subnode_parse(node)
 
     def do_header(self, node):
         """For a user defined section def a header field is present
         which should not be printed as such, so we comment it in the
         output."""
-        data = node.firstChild.data
-        self.add_text('\n/*\n %s \n*/\n'%data)
+        data = self.extract_text(node)
+        self.add_text('\n/*\n %s \n*/\n' % data)
         # If our immediate sibling is a 'description' node then we
         # should comment that out also and remove it from the parent
         # node's children.
         parent = node.parentNode
         idx = parent.childNodes.index(node)
         if len(parent.childNodes) >= idx + 2:
-            nd = parent.childNodes[idx+2]
+            nd = parent.childNodes[idx + 2]
             if nd.nodeName == 'description':
                 nd = parent.removeChild(nd)
                 self.add_text('\n/*')
-                self.generic_parse(nd)
+                self.subnode_parse(nd)
                 self.add_text('\n*/\n')
-
-    def do_simplesect(self, node):
-        kind = node.attributes['kind'].value
-        if kind in ('date', 'rcs', 'version'):
-            pass
-        elif kind == 'warning':
-            self.add_text(['\n', 'WARNING: '])
-            self.generic_parse(node)
-        elif kind == 'see':
-            self.add_text('\n')
-            self.add_text('See: ')
-            self.generic_parse(node)
-        else:
-            self.generic_parse(node)
-
-    def do_argsstring(self, node):
-        self.generic_parse(node, pad=1)
 
     def do_member(self, node):
         kind = node.attributes['kind'].value
         refid = node.attributes['refid'].value
         if kind == 'function' and refid[:9] == 'namespace':
-            self.generic_parse(node)
+            self.subnode_parse(node)
 
     def do_doxygenindex(self, node):
         self.multi = 1
@@ -372,80 +767,72 @@ class Doxy2SWIG:
             if not os.path.exists(fname):
                 fname = os.path.join(self.my_dir,  fname)
             if not self.quiet:
-                print( "parsing file: %s"%fname )
-            p = Doxy2SWIG(fname, self.include_function_definition, self.quiet)
+                print("parsing file: %s" % fname)
+            p = Doxy2SWIG(fname,
+                          with_function_signature = self.with_function_signature,
+                          with_type_info = self.with_type_info,
+                          with_constructor_list = self.with_constructor_list,
+                          with_attribute_list = self.with_attribute_list,
+                          with_overloaded_functions = self.with_overloaded_functions,
+                          textwidth = self.textwidth,
+                          quiet = self.quiet)
             p.generate()
-            self.pieces.extend(self.clean_pieces(p.pieces))
+            self.pieces.extend(p.pieces)
 
-    def write(self, fname):
-        o = my_open_write(fname)
-        if self.multi:
-            o.write(u"".join(self.pieces).encode('utf-8').strip())
-        else:
-            o.write(u"".join(self.clean_pieces(self.pieces)).encode('utf-8').strip())
-        o.close()
-
-    def clean_pieces(self, pieces):
-        """Cleans the list of strings given as `pieces`.  It replaces
-        multiple newlines by a maximum of 2 and returns a new list.
-        It also wraps the paragraphs nicely.
-        
-        """
-        ret = []
-        count = 0
-        for i in pieces:
-            if i == '\n':
-                count = count + 1
-            else:
-                if i == '";':
-                    if count:
-                        ret.append('\n')
-                elif count > 2:
-                    ret.append('\n\n')
-                elif count:
-                    ret.append('\n'*count)
-                count = 0
-                ret.append(i)
-
-        _data = "".join(ret)
-        ret = []
-        for i in _data.split('\n\n'):
-            if i == 'Parameters:' or i == 'Exceptions:' or i == 'Returns:':
-                ret.extend([i, '\n'+'-'*len(i), '\n\n'])
-            elif i.find('// File:') > -1: # leave comments alone.
-                ret.extend([i, '\n'])
-            else:
-                _tmp = textwrap.fill(i.strip(), break_long_words=False)
-                _tmp = self.lead_spc.sub(r'\1"\2', _tmp)
-                ret.extend([_tmp, '\n\n'])
-        return ret
-
-
-def convert(input, output, include_function_definition=True, quiet=False):
-    p = Doxy2SWIG(input, include_function_definition, quiet)
-    p.generate()
-    p.write(output)
-
+# MARK: main
 def main():
     usage = __doc__
     parser = optparse.OptionParser(usage)
-    parser.add_option("-n", '--no-function-definition',
+    parser.add_option("-f", '--function-signature',
                       action='store_true',
                       default=False,
-                      dest='func_def',
-                      help='do not include doxygen function definitions')
+                      dest='f',
+                      help='include function signature in the documentation. This is handy when not using swig auto-generated function definitions %feature("autodoc", [0,1])')
+    parser.add_option("-t", '--type-info',
+                      action='store_true',
+                      default=False,
+                      dest='t',
+                      help='include type information for arguments in function signatures. This is similar to swig autodoc level 1')
+    parser.add_option("-c", '--constructor-list',
+                      action='store_true',
+                      default=False,
+                      dest='c',
+                      help='generate a constructor list for class documentation. Useful for target languages where the object construction should be documented in the class documentation.')
+    parser.add_option("-a", '--attribute-list',
+                      action='store_true',
+                      default=False,
+                      dest='a',
+                      help='generate an attributes list for class documentation. Useful for target languages where class attributes should be documented in the class documentation.')
+    parser.add_option("-o", '--overloaded-functions',
+                      action='store_true',
+                      default=False,
+                      dest='o',
+                      help='collect all documentation for overloaded functions. Useful for target languages that have no concept of overloaded functions, but also to avoid having to attach the correct docstring to each function overload manually')
+    parser.add_option("-w", '--width', type="int",
+                      action='store',
+                      dest='w',
+                      default=80,
+                      help='textwidth for wrapping (default: 80). Note that the generated lines may include 2 additional spaces (for markdown).')
     parser.add_option("-q", '--quiet',
                       action='store_true',
                       default=False,
-                      dest='quiet',
+                      dest='q',
                       help='be quiet and minimize output')
     
     options, args = parser.parse_args()
     if len(args) != 2:
-        parser.error("error: no input and output specified")
-
-    convert(args[0], args[1], not options.func_def, options.quiet)
+        parser.error("no input and output specified")
     
+    p = Doxy2SWIG(args[0],
+                  with_function_signature = options.f,
+                  with_type_info = options.t,
+                  with_constructor_list = options.c,
+                  with_attribute_list = options.a,
+                  with_overloaded_functions = options.o,
+                  textwidth = options.w,
+                  quiet = options.q)
+    p.generate()
+    p.write(args[1])
 
 if __name__ == '__main__':
     main()

--- a/OpenMEEG/wrapping/src/doxy2swig.py
+++ b/OpenMEEG/wrapping/src/doxy2swig.py
@@ -47,7 +47,7 @@ def my_open_write(dest):
     if hasattr(dest, "write"):
         return dest
     else:
-        return open(dest, 'w')
+        return open(dest, 'wb')
 
 
 class Doxy2SWIG:    
@@ -215,7 +215,7 @@ class Doxy2SWIG:
                      'detaileddescription', 'includes')
             first = self.get_specific_nodes(node, names)
             for n in names:
-                if first.has_key(n):
+                if n not in first:
                     self.parse(first[n])
             self.add_text(['";','\n'])
             for n in node.childNodes:


### PR DESCRIPTION
Implement the old behaviour for h2ecogm. The choice is made on the number of parameters. I chosed to not conditionalize this  on the matrix version, even though the version number is now available for assemble.cpp.... but this is to be discussed.

The new innermost_interface detects the innermost interface (!) which is 2 for Alexamdre's example and not 3 as in the test. With this, it give the same matrices.

I think that there is also a subtle bug that I corrected in the detection of nested geometries (the dit_out variable was wrongly set. Maybe this is related to the TODO comment:
 // TODO test model HeadNNa0 appears as non-nested even if it is nested
This needs to be checked....

Tests still need to be added... I can do it if someone provides the proper files. Alex example is not that big (only the dipole file is, but we do not use it)... Use it ?
