### PR TITLE
Update OpenMEEG version to 2.4

### DIFF
--- a/OpenMEEG/CMakeLists.txt
+++ b/OpenMEEG/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 if (CMAKE_MAJOR_VERSION EQUAL 3)
     cmake_policy(SET CMP0048 NEW)
     cmake_policy(SET CMP0037 NEW)
-    set(PROJECT_VERSION VERSION 2.3.99)
+    set(PROJECT_VERSION VERSION 2.4.0.0)
 endif()
 # The second path is temporary untill these are integrated in cmake...
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_SOURCE_DIR}/cmake/FortranCInterface)


### PR DESCRIPTION
the tools were still showing they were compiled with 2.3.99
please accept this PR as soon as you think we're really good for release 2.4 