### PR TITLE
[BUG-fix] don't use fancy c++ with /Za option in MSVC

### DIFF
--- a/OpenMEEG/src/geometry.cpp
+++ b/OpenMEEG/src/geometry.cpp
@@ -40,6 +40,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 #include <geometry.h>
 #include <geometry_reader.h>
 #include <geometry_io.h>
+#include <ciso646>
 
 namespace OpenMEEG {
 

--- a/OpenMEEG/src/interface.cpp
+++ b/OpenMEEG/src/interface.cpp
@@ -39,6 +39,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 #include <interface.h>
 #include <algorithm>
+#include <ciso646>
 
 namespace OpenMEEG {
 

--- a/OpenMEEG/src/sensors.cpp
+++ b/OpenMEEG/src/sensors.cpp
@@ -40,6 +40,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 #include <algorithm>
 #include <sensors.h>
 #include <danielsson.h>
+#include <ciso646>
 
 namespace OpenMEEG {
 

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -1,6 +1,6 @@
 if(MSVC)
     # to allow the use of and, or instead of && ||
-    add_compile_options("/Za")
+    # add_compile_options("/Za")
 endif()
 
 #---------------------------------------------------------------

--- a/cmake/CompilerOptions.cmake
+++ b/cmake/CompilerOptions.cmake
@@ -1,8 +1,3 @@
-if(MSVC)
-    # to allow the use of and, or instead of && ||
-    # add_compile_options("/Za")
-endif()
-
 #---------------------------------------------------------------
 # Test and setup the C++ compiler features
 #---------------------------------------------------------------


### PR DESCRIPTION
[written by Sik]
This PR responds to The problem of using coarse compiler options as a wildcard when doing multiplatform software. Cutting corners to use alternative operators by changing the compiler options (with all its collateral effects) instead of adding the bearly minimum, means that all have been chasing ghosts for 2.5 weeks. It was much easier to just add the alternative macros to those 3 cpp files that need it.

Fix #312. Close #313. 