### PR TITLE
Matio bug

### DIFF
--- a/OpenMEEGMaths/include/MatlabIO.H
+++ b/OpenMEEGMaths/include/MatlabIO.H
@@ -284,6 +284,9 @@ namespace OpenMEEG {
             void read(mat_t* mat,LinOp& linop) const {
                 matvar_t* matvar = read_header<TYPE>(mat,linop);
                 TYPE& O = dynamic_cast<TYPE&>(linop);
+                const uint64_t nbytes = linop.size()*matvar->data_size;
+                if (nbytes!=static_cast<uint64_t>(matvar->nbytes))
+                    throw maths::MatioError("Matio inconsistency: the number of bytes read by matio is not coherent with the matrix size.");
                 O.reference_data(static_cast<double*>(matvar->data));
                 matvar->mem_conserve = 1;
                 Mat_VarFree(matvar);
@@ -292,7 +295,7 @@ namespace OpenMEEG {
             void read_sparse(mat_t* mat,LinOp& linop) const {
                 matvar_t*     matvar = read_header<SparseMatrix>(mat,linop);
                 SparseMatrix& m      = dynamic_cast<SparseMatrix&>(linop);
-                std::cout << "Using variable with name : " << matvar->name << std::endl;
+                std::cout << "Using variable with name: " << matvar->name << std::endl;
 
                 mat_sparse_t* sparse = static_cast<mat_sparse_t*>(matvar->data);
                 size_t _nz = sparse->nzmax;

--- a/OpenMEEGMaths/include/OMassert.H
+++ b/OpenMEEGMaths/include/OMassert.H
@@ -22,7 +22,7 @@
    ? static_cast<void>(0)						\
    : Assert(om_str(expr),__FILE__,__LINE__,__PRETTY_FUNCTION__))
 
-//  Remove om_assert wgen NDEBUG is defined.
+//  Remove om_assert when NDEBUG is defined.
 //  Not clear this is useful...
 
 #define IGNORE_NDEBUG


### PR DESCRIPTION
Here is a small patch to add a sanity check other the overflow bug in matio. With this patch, we issue the message:
bali-> apps/tools/om_matrix_info -i ~/Downloads/openmeeg_dsm.mat 
apps/tools/om_matrix_info version 2.4.0 compiled at Aug 16 2018 14:56:36 using OpenMP
 Executing using 4 threads.

Loading : /user/papadop/home/Downloads/openmeeg_dsm.mat
terminate called after throwing an instance of 'OpenMEEG::maths::MatioError'
  what():  Exception: Matio inconsistency: the number of bytes read by matio is not coherent with the matrix size.
Abort (core dumped)

So it does not avoid the core dump (we could add some try {} catch {} to avoid the core dump), but at least the message clearly states what is the problem.

To fully solve the problem, we need matio to correct it unfortunately. 

