### PR TITLE
FIX: make sure meg sensors as numbers with integration points are still ok

### DIFF
--- a/OpenMEEG/src/sensors.cpp
+++ b/OpenMEEG/src/sensors.cpp
@@ -90,7 +90,6 @@ namespace OpenMEEG {
         std::string s, buf;
         Strings names;
         Strings tokens;
-        Strings::const_iterator tokensIterator;
         bool labeled = false;
         size_t nlin = 0;
         size_t ncol = 0;

--- a/OpenMEEG/src/sensors.cpp
+++ b/OpenMEEG/src/sensors.cpp
@@ -107,7 +107,9 @@ namespace OpenMEEG {
                         ncol++;
                     }
                 }
-                tokensIterator = tokens.begin();
+                if (ncol >= 7) {
+                    labeled = true;
+                }
                 for ( size_t j = 0; j < tokens[0].size(); ++j) {
                     if ( isalpha(tokens[0][j]) && (tokens[0][j] != 'e') && (tokens[0][j] != 'E' ) ) {
                         labeled = true;


### PR DESCRIPTION
closes #353 

cc @ftadel

@papadop @mclerc this commit https://github.com/openmeeg/openmeeg/commit/cbb9d0f574c32d40fedd12fd8489d3cdd74fdbb4 had broken brainstorm in 2014.

@massich can you see if you can cut a new minor release? also we need a what's new page. @massich can you help with this? thanks a lot