### PR TITLE
Mesh work (WIP)

### DIFF
--- a/OpenMEEG/include/mesh.h
+++ b/OpenMEEG/include/mesh.h
@@ -94,34 +94,43 @@ namespace OpenMEEG {
         // Constructors:
         /// default constructor
 
-        Mesh(): Triangles(), name_(""), all_vertices_(0), outermost_(false), allocate_(false), current_barrier_(false), isolated_(false) { }
+        Mesh(): Triangles(),name_(""),all_vertices_(0),outermost_(false),allocate_(false),current_barrier_(false),isolated_(false) { }
 
         /// constructor from scratch (add vertices/triangles one by one) 
         /// \param nv allocate space for vertices
         /// \param nt allocate space for triangles
 
-        Mesh(const unsigned& nv,const unsigned& nt): name_(""), outermost_(false), allocate_(true), current_barrier_(false), isolated_(false) {
+        Mesh(const unsigned& nv,const unsigned& nt): name_(""),outermost_(false),allocate_(true),current_barrier_(false),isolated_(false) {
             all_vertices_ = new Vertices;
             all_vertices_->reserve(nv); // allocates space for the vertices
             reserve(nt);
         }
 
-        /// constructor from another mesh \param m
+        /// Constructor from another mesh \param m
 
+        Mesh(const Mesh&& m): Triangles(m),name_(m.name_),all_vertices_(m.all_vertices_),outermost_(m.outermost_),allocate_(m.allocate_),current_barrier_(m.current_barrier_),isolated_(m.isolated_) { }
+
+        Mesh(const Mesh&) = delete;
+        #if 0
         Mesh(const Mesh& m): Triangles(), current_barrier_(false), isolated_(false) { *this = m; }
+        #endif
 
-        /// constructor using an outisde storage for vertices \param av Where to store vertices \param name Mesh name
+        /// Constructor using an existing set of vertices
+        /// \param av: vertices
+        /// \param name Mesh name
 
-        Mesh(Vertices& av,const std::string name = ""): name_(name), all_vertices_(&av), outermost_(false), allocate_(false), current_barrier_(false), isolated_(false) {
-            set_vertices_.insert(all_vertices_->begin(), all_vertices_->end()); 
+        Mesh(Vertices& av,const std::string name=""): name_(name),all_vertices_(&av),outermost_(false),allocate_(false),current_barrier_(false),isolated_(false) {
+            set_vertices_.insert(all_vertices_->begin(),all_vertices_->end()); 
         }
 
-        /// constructor loading directly a mesh file named \param filename . Be verbose if \param verbose is true. The mesh name is \param n .
+        /// Constructor loading directly a mesh file named \param filename.
+        /// Be verbose if \param verbose is true.
+        /// The mesh name is \param n.
 
-        Mesh(std::string filename,const bool verbose=true,const std::string n=""): name_(n), outermost_(false), allocate_(true), current_barrier_(false), isolated_(false) {
-            unsigned nb_v = load(filename, false, false); 
+        Mesh(std::string filename,const bool verbose=true,const std::string n=""): name_(n),outermost_(false),allocate_(true),current_barrier_(false),isolated_(false) {
+            unsigned nb_v = load(filename,false,false); 
             all_vertices_ = new Vertices(nb_v); // allocates space for the vertices
-            load(filename, verbose);
+            load(filename,verbose);
         }
 
         /// Destructor
@@ -163,7 +172,9 @@ namespace OpenMEEG {
         bool has_self_intersection() const; ///< \brief check if the mesh self-intersects
         bool intersection(const Mesh&) const; ///< \brief check if the mesh intersects another mesh
         bool has_correct_orientation() const; ///< \brief check the local orientation of the mesh triangles
+        #if 0
         void build_mesh_vertices(); ///< \brief construct the list of the mesh vertices out of its triangles
+        #endif
         void generate_indices(); ///< \brief generate indices (if allocate)
         void update(); ///< \brief recompute triangles normals, area, and links
         void merge(const Mesh&, const Mesh&); ///< properly merge two meshes into one
@@ -254,11 +265,14 @@ namespace OpenMEEG {
 
         // IO:s ----------------------------------------------------------------------------
 
+        Mesh& operator=(const Mesh&) = delete;
+        #if 0
         Mesh& operator=(const Mesh& m) {
-            if ( this != &m )
+            if (this!=&m)
                 copy(m);
             return *this;
         }
+        #endif
 
         friend std::istream& operator>>(std::istream& is, Mesh& m); ///< \brief insert a triangle into the mesh
 
@@ -269,7 +283,9 @@ namespace OpenMEEG {
         typedef std::map<std::pair<const Vertex *, const Vertex *>, int> EdgeMap; 
 
         void destroy();
+        #if 0
         void copy(const Mesh&);
+        #endif
 
         // regarding mesh orientation
 

--- a/OpenMEEG/src/assembleHeadMat.cpp
+++ b/OpenMEEG/src/assembleHeadMat.cpp
@@ -78,7 +78,7 @@ namespace OpenMEEG {
             nb_vertices=0;
             i_first=0;
             for(std::vector<std::string>::const_iterator mit=git->begin();mit!=git->end();++mit){
-                const Mesh msh=geo.mesh(*mit);
+                const Mesh& msh = geo.mesh(*mit);
                 if(msh.outermost()){
                     nb_vertices+=msh.nb_vertices();
                     if(i_first==0)
@@ -87,7 +87,7 @@ namespace OpenMEEG {
             }
             coef=M(i_first,i_first)/nb_vertices;
             for(std::vector<std::string>::const_iterator mit=git->begin();mit!=git->end();++mit){
-                Mesh msh=geo.mesh(*mit);
+                const Mesh& msh=geo.mesh(*mit);
                 if(msh.outermost())
                     for(Mesh::const_vertex_iterator vit1=msh.vertex_begin();vit1!=msh.vertex_end();++vit1){
                         #pragma omp parallel for

--- a/OpenMEEG/src/mesh.cpp
+++ b/OpenMEEG/src/mesh.cpp
@@ -44,6 +44,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 namespace OpenMEEG {
 
+#if 0
     void Mesh::copy(const Mesh& m) {
 
         if (m.allocate_) {
@@ -64,14 +65,14 @@ namespace OpenMEEG {
             all_vertices_ = m.all_vertices_;
             set_vertices_ = m.set_vertices_;
             allocate_ = false;
-            for (Triangles::const_iterator tit = m.begin(); tit != m.end(); ++tit) {
+            for (Triangles::const_iterator tit = m.begin(); tit != m.end(); ++tit)
                 push_back(*tit);
-            }
             build_mesh_vertices();
         }
         outermost_ = m.outermost_;
         name_      = m.name_;
     }
+#endif
 
     /// Print informations about the mesh 
 
@@ -100,17 +101,19 @@ namespace OpenMEEG {
         }
     }
 
+#if 0
     void Mesh::build_mesh_vertices() {
 
         // Sets do not preserve the order, and we would like to preserve it so we push_back in the vector as soon as the element is unique.
 
-        std::set<const Vertex *> mesh_v;
+        std::set<const Vertex*> mesh_v;
         vertices_.clear();
         for (const_iterator tit = begin(); tit != end(); ++tit)
             for (Triangle::const_iterator sit = tit->begin(); sit != tit->end(); ++sit)
                 if (mesh_v.insert(*sit).second)
                     vertices_.push_back(const_cast<Vertex *>(*sit));
     }
+#endif
 
     void Mesh::destroy() {
         if (allocate_)
@@ -140,22 +143,21 @@ namespace OpenMEEG {
         return is;
     }
 
-    /// properly add vertex to the list. (if not already added)
+    /// Properly add vertex to the list. (if not already added)
     void Mesh::add_vertex(const Vertex& v) {
 
-        // try to insert the vertex to the set
-        std::pair<std::set<Vertex>::iterator, bool> ret = set_vertices_.insert(v);
+        // Try to insert the vertex to the set
+        std::pair<std::set<Vertex>::iterator,bool> ret = set_vertices_.insert(v);
         if (ret.second) {
-            // if inserted, then it is a new vertex, and we add it to both lists
+            // If inserted, then it is a new vertex, and we add it to both lists
             all_vertices_->push_back(v);
-            vertices_.push_back(&(*all_vertices_->rbegin()));
+            vertices_.push_back(&all_vertices_->back());
         } else {
-            // if not inserted, Either it belongs to another mesh or it was dupplicated in the same mesh
+            // If not inserted, either it belongs to another mesh or it was duplicated in the same mesh
             // TODO this may take time for too big redundant mesh
             Vertices::iterator vit = std::find(all_vertices_->begin(), all_vertices_->end(), v);
-            if (std::find(vertices_.begin(), vertices_.end(), &(*vit)) == vertices_.end()) {
+            if (std::find(vertices_.begin(), vertices_.end(), &(*vit)) == vertices_.end())
                 vertices_.push_back(&(*vit));
-            }
         }
     }
 
@@ -370,39 +372,39 @@ namespace OpenMEEG {
         }
     }
 
-    /// For IO:s -------------------------------------------------------------------------------------------
+    /// For IOs
 
-    unsigned Mesh::load(const std::string& filename, const bool& verbose, const bool& read_all) {
+    unsigned Mesh::load(const std::string& filename,const bool& verbose,const bool& read_all) {
 
-        if (size() != 0)
+        if (size()!=0)
             destroy();
 
-        if (read_all && ( all_vertices_ == 0) ) {
-            unsigned nb_v = load(filename, false, false); // first allocates memory for the vertices
+        if (read_all && (all_vertices_==0)) {
+            unsigned nb_v = load(filename,false,false); // first allocates memory for the vertices
             all_vertices_ = new Vertices;
             all_vertices_->reserve(nb_v); 
             allocate_ = true;
         }
 
         std::string extension = getNameExtension(filename);
-        std::transform(extension.begin(), extension.end(), extension.begin(), (int(*)(int))std::tolower);
+        std::transform(extension.begin(),extension.end(),extension.begin(),(int(*)(int))std::tolower);
         unsigned return_value = 0;
 
         if (verbose)
             std::cout << "loading : " << filename << " as a \"" << extension << "\" file."<< std::endl;
 
-        if (extension == std::string("vtk")) {
-            return_value = load_vtk(filename, read_all);
+        if (extension==std::string("vtk")) {
+            return_value = load_vtk(filename,read_all);
         } else if (extension == std::string("tri")) {
-            return_value = load_tri(filename, read_all);
+            return_value = load_tri(filename,read_all);
         } else if (extension == std::string("bnd")) {
-            return_value = load_bnd(filename, read_all);
+            return_value = load_bnd(filename,read_all);
         } else if (extension == std::string("mesh")) {
-            return_value = load_mesh(filename, read_all);
+            return_value = load_mesh(filename,read_all);
         } else if (extension == std::string("off")) {
-            return_value = load_off(filename, read_all);
+            return_value = load_off(filename,read_all);
         } else if (extension == std::string("gii")) {
-            return_value = load_gifti(filename, read_all);
+            return_value = load_gifti(filename,read_all);
         } else {
             std::cerr << "IO: load: Unknown mesh file format for " << filename << std::endl;
             exit(1);
@@ -484,29 +486,29 @@ namespace OpenMEEG {
         return 0;
     }
 
-    unsigned Mesh::load_vtk(std::istream& is, const bool& read_all) {
+    unsigned Mesh::load_vtk(std::istream& is,const bool& read_all) {
 
-        // get length of file:
-        is.seekg (0, ios::end);
+        // Compute length of file:
+
+        is.seekg (0,ios::end);
         int length = is.tellg();
-        is.seekg (0, ios::beg);
-
-        // allocate memory:
-        char * buffer = new char [length];
+        is.seekg (0,ios::beg);
 
         // read data as a block:
-        is.read (buffer, length);
+
+        char* buffer = new char[length];
+        is.read(buffer,length);
 
         // held buffer by the array buf:
         vtkCharArray* buf = vtkCharArray::New();
-        buf->SetArray(buffer, length, 1);
+        buf->SetArray(buffer,length,1);
 
         vtkPolyDataReader* reader = vtkPolyDataReader::New();
         reader->SetInputArray(buf); // Specify 'buf' to be used when reading from a string
         reader->SetReadFromInputString(1);  // Enable reading from the InputArray 'buf' instead of the default, a file
 
         unsigned return_value = 0;
-        return_value = get_data_from_vtk_reader(reader, read_all);
+        return_value = get_data_from_vtk_reader(reader,read_all);
 
         delete[] buffer;
         reader->Delete();
@@ -516,8 +518,7 @@ namespace OpenMEEG {
 
     unsigned Mesh::load_vtk(const std::string& filename, const bool& read_all) {
 
-        std::string s = filename;
-        vtkPolyDataReader *reader = vtkPolyDataReader::New();
+        vtkPolyDataReader* reader = vtkPolyDataReader::New();
         reader->SetFileName(filename.c_str()); // Specify file name of vtk data file to read
         if (!reader->IsFilePolyData()) {
             std::cerr << "Mesh \"" << name_ << "\" is not a valid vtk poly data file" << std::endl;
@@ -526,7 +527,7 @@ namespace OpenMEEG {
         }
 
         unsigned return_value = 0;
-        return_value = get_data_from_vtk_reader(reader, read_all);
+        return_value = get_data_from_vtk_reader(reader,read_all);
         return return_value;
     }
     #endif
@@ -730,7 +731,6 @@ namespace OpenMEEG {
 
     unsigned Mesh::load_tri(const std::string& filename, const bool& read_all) {
 
-        std::string s = filename;
         std::ifstream f(filename.c_str());
         if (!f.is_open()) {
             std::ostringstream ost;
@@ -799,7 +799,6 @@ namespace OpenMEEG {
 
     unsigned Mesh::load_bnd(const std::string& filename, const bool& read_all) {        
 
-        std::string s = filename;
         std::ifstream f(filename.c_str());
 
         if (!f.is_open()) {
@@ -841,7 +840,6 @@ namespace OpenMEEG {
 
     unsigned Mesh::load_off(const std::string& filename, const bool& read_all) {
 
-        std::string s = filename;
         std::ifstream f(filename.c_str());
         if (!f.is_open()) {
             std::cerr << "Error opening OFF file: " << filename << std::endl;

--- a/cmake/thirdParties.cmake
+++ b/cmake/thirdParties.cmake
@@ -5,7 +5,6 @@
 set(BLA_DEFINITIONS)
 set(BLA_VENDOR "OpenBLAS" CACHE STRING "BLAS/LAPACK implementation")
 
-
 if (BLA_VENDOR MATCHES Intel)
     if ("$ENV{MKLROOT}" STREQUAL "")
         message(FATAL_ERROR "MKLROOT is not set. Please source the Intel MKL mklvars.sh file.")
@@ -52,9 +51,9 @@ else()
 endif()
 
 find_package(Threads)
-
 find_package(OpenMP)
-if(BLA_STATIC)
+
+if (BLA_STATIC)
     set(MATIO_USE_STATIC_LIBRARIES TRUE) # XXX This should be an option
 endif()
 

--- a/data/README.rst
+++ b/data/README.rst
@@ -46,19 +46,19 @@ OpenMEEG definitions:
 
 Namings:
 --------
-For ease of explanation, we consider the naming as follow:
+For ease of explanation, we adopt here the following naming convention:
 - meshes: are named in lower case
 - interfaces: in CamelCase
 - domains: in UPPERCASE
-
-but this convention is up to you.
 
 A *.geom file* contains:
 
 1. A header section: 
 --------------------
 
-Version 1.1 and later date from after the introduction of non-nested geometries::
+This header defines the type of the geom file.
+Version 1.0 was the initial file format. It was only allowing nested head models. It is now deprecated but still supported.
+The newer Version 1.1 has been introduced to support non-nested geometries::
 
   # Domain Description 1.1                             
 

--- a/tests/test_mesh_ios.cpp
+++ b/tests/test_mesh_ios.cpp
@@ -44,45 +44,50 @@ int main (int argc, char** argv)
 
     std::cout << "Mesh : " << argv[1] << std::endl;
 
-    Mesh mesh_orig;
-    mesh_orig.load(argv[1]);
+    Mesh mesh;
+    mesh.load(argv[1]);
 
-    Mesh mesh = mesh_orig;
+    //  TRI
 
-    // // TRI
     mesh.save("tmp.tri");
-    mesh.load("tmp.tri");
+    Mesh trimesh;
+    trimesh.load("tmp.tri");
 
-    om_error(are_equal(mesh, mesh_orig));
+    om_error(are_equal(mesh,trimesh));
 
     // VTK
     mesh.save("tmp.vtk");
 #ifdef USE_VTK
-    mesh.load("tmp.vtk");
-    om_error(are_equal(mesh, mesh_orig));
+    Mesh vtkmesh;
+    vtkmesh.load("tmp.vtk");
+    om_error(are_equal(mesh,vtkmesh));
 #endif
 
     // GIFTI
 #ifdef USE_GIFTI
     mesh.save("tmp.gii");
-    mesh.load("tmp.gii");
-    om_error(are_equal(mesh, mesh_orig));
+    Mesh giftimesh;
+    giftimesh.load("tmp.gii");
+    om_error(are_equal(mesh,giftimesh));
 #endif
 
-
     // MESH
+
     mesh.save("tmp.mesh");
-    mesh.load("tmp.mesh");
-    om_error(are_equal(mesh, mesh_orig));
+    Mesh mmesh;
+    mmesh.load("tmp.mesh");
+    om_error(are_equal(mesh,mmesh));
 
     // BND && OFF that do not store normals
+
     mesh.save("tmp.bnd");
     mesh.save("tmp.off");
     mesh.info();
 
     Mesh mesh1;
-    Mesh mesh2;
     mesh1.load("tmp.bnd");
+
+    Mesh mesh2;
     mesh2.load("tmp.off");
     om_error(are_equal(mesh1, mesh2));
 

--- a/wrapping/src/openmeeg.i
+++ b/wrapping/src/openmeeg.i
@@ -111,7 +111,7 @@ namespace std {
     %template(vector_vertex) vector<OpenMEEG::Vertex>;
     %template(vector_pvertex) vector<OpenMEEG::Vertex *>;
     %template(vector_triangle) vector<OpenMEEG::Triangle>;
-    %template(vector_mesh) vector<OpenMEEG::Mesh>;
+#    %template(vector_mesh) vector<OpenMEEG::Mesh>;
     %template(vector_string) vector<std::string>;
     %template(vector_interface) vector<OpenMEEG::Interface>;
 }
@@ -120,7 +120,7 @@ namespace OpenMEEG {
     %typedef std::vector<OpenMEEG::Vertex> Vertices;
     %typedef std::vector<OpenMEEG::Vertex *> PVertices;
     %typedef std::vector<OpenMEEG::Triangle> Triangles;
-    %typedef std::vector<OpenMEEG::Mesh> Meshes;
+#    %typedef std::vector<OpenMEEG::Mesh> Meshes;
     %typedef std::vector<std::string>    Strings;
 }
 


### PR DESCRIPTION
During the python coding sprint, I have has a look at the Mesh classes.
I do not like them much (it's not new)...
Yet, I think we can improve things a little.
This is a first step which removes all the logic allowing to copy meshes. The copy constructor is deleted, and we use mesh references whenever copies were made. In some cases, I had to change slightly the logic, but I think that the initial intent of the code is respected in those cases.
One minor point is that swig does not know to wrap vectors of classes with no copy constructor (here the class Meshes==std::vector<Mesh>). Until I find a workaround (there seems to be one), I disabled the wrapping of this class. But I'm not totally sure that we really need it either....
There are two methods that can be removed (not yet done. They are only #if'ed out for now. see mesh.cpp).
This is a POC/WIP. Let us see what tester will say....

I intend to go a little further in the restructuring of this code (the all_vertices stuff seems in particular weirdly crafted into the mesh classes).

