### PR TITLE
Correct vertex access for triangles.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.9)
 project (OpenMEEG VERSION 2.4.9999 LANGUAGES C CXX)
 
-set(CMAKE_CXX_STANDARD 11)  # use c++11
+set(CMAKE_CXX_STANDARD 17)  # use c++17
 
 set(OpenMEEG_HEADER_INSTALLDIR include) # XXX I don't know why this should be here
 

--- a/OpenMEEG/include/analytics.h
+++ b/OpenMEEG/include/analytics.h
@@ -46,26 +46,35 @@ namespace OpenMEEG {
 
     inline double integral_simplified_green(const Vect3& p0x, const double norm2p0x,
                                             const Vect3& p1x, const double norm2p1x,
-                                            const Vect3& p1p0, const double norm2p1p0)
+                                            const Vect3& p1p0,const double norm2p1p0)
     {
         //  The quantity arg is normally >= 1, verifying this relates to a triangular inequality
         //  between p0, p1 and x.
         //  Consequently, there is no need of an absolute value in the first case.
 
-        const double arg = (norm2p0x * norm2p1p0 - p0x * p1p0) / (norm2p1x * norm2p1p0 - p1x * p1p0);
-        return (std::isnormal(arg) && arg > 0.0) ? log(arg) : fabs(log(norm2p1x / norm2p0x));
+        const double arg = (norm2p0x*norm2p1p0-dotprod(p0x,p1p0))/(norm2p1x*norm2p1p0-dotprod(p1x,p1p0));
+        return (std::isnormal(arg) && arg>0.0) ? log(arg) : fabs(log(norm2p1x/norm2p0x));
     }
 
-    class OPENMEEG_EXPORT analyticS
-    {
-        Vect3 p0, p1, p2; //!< vertices of the triangle
-        Vect3 p2p1, p1p0, p0p2;
-        Vect3 nu0, nu1, nu2;
-        Vect3 n;
-        double norm2p2p1, norm2p1p0, norm2p0p2;
-        double tanTHETA0m, tanTHETA0p, tanTHETA1m, tanTHETA1p, tanTHETA2m, tanTHETA2p;
-        
-        void init_aux() {
+    class OPENMEEG_EXPORT analyticS {
+
+        void initialize(const Vect3& v0,const Vect3& v1,const Vect3& v2) {
+            // All computations needed when the first triangle of integration is changed
+
+            p0 = v0;
+            p1 = v1;
+            p2 = v2;
+
+            p1p0 = p1-p0;
+            p2p1 = p2-p1;
+            p0p2 = p0-p2;
+
+            norm2p1p0 = p1p0.norm();
+            norm2p2p1 = p2p1.norm();
+            norm2p0p2 = p0p2.norm();
+        }
+
+        void finish_intialization() {
             nu0 = (p1p0^n);
             nu1 = (p2p1^n);
             nu2 = (p0p2^n);
@@ -75,38 +84,26 @@ namespace OpenMEEG {
         }
 
     public:
-        analyticS(){}
-        ~analyticS(){}
-        void init(const Triangle& T)
-        {
-            // all computations needed when the first triangle of integration is changed
-            p0 = T.s1();
-            p1 = T.s2();
-            p2 = T.s3();
 
-            p1p0 = p1-p0; p2p1 = p2-p1; p0p2 = p0-p2;
-            norm2p1p0 = p1p0.norm(); norm2p2p1 = p2p1.norm(); norm2p0p2 = p0p2.norm();
+         analyticS() { }
+        ~analyticS() { }
 
-            n = T.normal(); // since triangle's normal is already normalized
-            init_aux();
+        void init(const Triangle& T) {
+            initialize(T.vertex(0),T.vertex(1),T.vertex(2));
+            n = T.normal();
+            finish_intialization();
         }
 
-        void init(const Vect3& v0, const Vect3& v1, const Vect3& v2)
-        {
-            // all computations needed when the first triangle of integration is changed
-            p0 = v0;
-            p1 = v1;
-            p2 = v2;
-            p1p0 = p1-p0; p2p1 = p2-p1; p0p2 = p0-p2;
-            norm2p1p0 = p1p0.norm(); norm2p2p1 = p2p1.norm(); norm2p0p2 = p0p2.norm();
-
+        #if 1
+        void init(const Vect3& v0,const Vect3& v1,const Vect3& v2) {
+            initialize(v0,v1,v2);
             n = p1p0^p0p2;
             n /= n.norm();
-            init_aux();
+            finish_intialization();
         }
+        #endif
 
-        inline double f(const Vect3& x) const
-        {
+        double f(const Vect3& x) const {
             // analytical value of the internal integral of S operator at point X
             const Vect3& p0x = p0-x;
             const Vect3& p1x = p1-x;
@@ -115,76 +112,80 @@ namespace OpenMEEG {
             const double norm2p1x = p1x.norm();
             const double norm2p2x = p2x.norm();
 
-            const double g0 = integral_simplified_green(p0x, norm2p0x, p1x, norm2p1x, p1p0, norm2p1p0);
-            const double g1 = integral_simplified_green(p1x, norm2p1x, p2x, norm2p2x, p2p1, norm2p2p1);
-            const double g2 = integral_simplified_green(p2x, norm2p2x, p0x, norm2p0x, p0p2, norm2p0p2);
+            const double g0 = integral_simplified_green(p0x,norm2p0x,p1x,norm2p1x,p1p0,norm2p1p0);
+            const double g1 = integral_simplified_green(p1x,norm2p1x,p2x,norm2p2x,p2p1,norm2p2p1);
+            const double g2 = integral_simplified_green(p2x,norm2p2x,p0x,norm2p0x,p0p2,norm2p0p2);
 
-            const double alpha = p0x*n;
+            const double alpha = dotprod(p0x,n);
 
-            return (((p0x*nu0)*g0+(p1x*nu1)*g1+(p2x*nu2)*g2)-alpha*x.solangl(p0, p1, p2));
+            return ((dotprod(p0x,nu0)*g0+dotprod(p1x,nu1)*g1+dotprod(p2x,nu2)*g2)-alpha*x.solid_angle(p0,p1,p2));
         }
+
+    private:
+
+        Vect3 p0, p1, p2; //!< vertices of the triangle
+        Vect3 p2p1, p1p0, p0p2;
+        Vect3 nu0, nu1, nu2;
+        Vect3 n;
+        double norm2p2p1, norm2p1p0, norm2p0p2;
+        double tanTHETA0m, tanTHETA0p, tanTHETA1m, tanTHETA1p, tanTHETA2m, tanTHETA2p;
     };
 
-    class OPENMEEG_EXPORT analyticD3
-    {
-        const Vect3 &v1, &v2, &v3;
-
+    class OPENMEEG_EXPORT analyticD3 {
     public:
-        analyticD3(const Triangle& T): v1(T.s1()), v2(T.s2()), v3(T.s3()) {}
 
-        ~analyticD3() {}
+         analyticD3(const Triangle& T): v1(T.vertex(0)),v2(T.vertex(1)),v3(T.vertex(2)) {}
+        ~analyticD3() { }
 
         inline Vect3 f(const Vect3& x) const {
             //Analytical value of the inner integral in operator D. See DeMunck article for further details.
             //  for non-optimized version of operator D
             //  returns in a vector, the inner integrals of operator D on a triangle viewed as a part of the 3
             //  P1 functions it has a part in.
-            Vect3 Y1 = v1-x;
-            Vect3 Y2 = v2-x;
-            Vect3 Y3 = v3-x;
-            double y1 = Y1.norm();
-            double y2 = Y2.norm();
-            double y3 = Y3.norm();
-            double d = Y1*(Y2^Y3);
 
-            double derr = 1e-10;
-            if ( fabs(d) < derr ) {
+            //  First part omega is just x.solid_angle(v1,v2,v3)
+
+            const Vect3& Y1 = v1-x;
+            const Vect3& Y2 = v2-x;
+            const Vect3& Y3 = v3-x;
+            const double y1 = Y1.norm();
+            const double y2 = Y2.norm();
+            const double y3 = Y3.norm();
+            const double d  = det(Y1,Y2,Y3);
+
+            if (fabs(d)<1e-10)
                 return 0.0;
-            }
 
-            double omega = 2. * atan2(d, (y1*y2*y3 + y1*(Y2*Y3) + y2*(Y3*Y1) + y3*(Y1*Y2)));
+            const double omega = 2*atan2(d,(y1*y2*y3+y1*dotprod(Y2,Y3)+y2*dotprod(Y3,Y1)+y3*dotprod(Y1,Y2)));
 
-            Vect3 Z1 = Y2^Y3;
-            Vect3 Z2 = Y3^Y1;
-            Vect3 Z3 = Y1^Y2;
-            Vect3 D1 = Y2-Y1;
-            Vect3 D2 = Y3-Y2;
-            Vect3 D3 = Y1-Y3;
-            double d1 = D1.norm();
-            double d2 = D2.norm();
-            double d3 = D3.norm();
-            double g1 = -1.0/d1*log((y1*d1+Y1*D1)/(y2*d1+Y2*D1));
-            double g2 = -1.0/d2*log((y2*d2+Y2*D2)/(y3*d2+Y3*D2));
-            double g3 = -1.0/d3*log((y3*d3+Y3*D3)/(y1*d3+Y1*D3));
-            Vect3 N = Z1+Z2+Z3;
-            double invA = 1.0/N.norm2();
-            Vect3 S = D1*g1+D2*g2+D3*g3;
-            Vect3 omega_i;
-            omega_i.x() = invA*(Z1*N*omega+d*(D2*S));
-            omega_i.y() = invA*(Z2*N*omega+d*(D3*S));
-            omega_i.z() = invA*(Z3*N*omega+d*(D1*S));
+            const Vect3& Z1 = crossprod(Y2,Y3);
+            const Vect3& Z2 = crossprod(Y3,Y1);
+            const Vect3& Z3 = crossprod(Y1,Y2);
+            const Vect3& D1 = v2-v1;
+            const Vect3& D2 = v3-v2;
+            const Vect3& D3 = v1-v3;
+            const double d1 = D1.norm();
+            const double d2 = D2.norm();
+            const double d3 = D3.norm();
+            const double g1 = log((y2*d1+dotprod(Y2,D1))/(y1*d1+dotprod(Y1,D1)))/d1;
+            const double g2 = log((y3*d2+dotprod(Y3,D2))/(y2*d2+dotprod(Y2,D2)))/d2;
+            const double g3 = log((y1*d3+dotprod(Y1,D3))/(y3*d3+dotprod(Y3,D3)))/d3;
+            const Vect3& N = Z1+Z2+Z3;
+            const double invA = 1.0/N.norm2();
+            const Vect3& S = D1*g1+D2*g2+D3*g3;
 
-            return omega_i;
+            return invA*(omega*Vect3(dotprod(Z1,N),dotprod(Z2,N),dotprod(Z3,N))+d*Vect3(dotprod(D2,S),dotprod(D3,S),dotprod(D1,S)));
         }
+
+    private:
+
+        const Vect3 &v1, &v2, &v3;
     };
 
-    class OPENMEEG_EXPORT analyticDipPot
-    {
-        Vect3 r0;
-        Vect3 q;
-
+    class OPENMEEG_EXPORT analyticDipPot {
     public:
-        analyticDipPot(){}
+
+         analyticDipPot(){}
         ~analyticDipPot(){}
 
         inline void init( const Vect3& _q, const Vect3& _r0) {
@@ -193,52 +194,71 @@ namespace OpenMEEG {
         }
 
         inline double f(const Vect3& x) const {
-            // RK: A = q.(x-r0)/||^3
-            Vect3 r = x-r0;
-            double rn = r.norm();
-            return (q*r)/(rn*rn*rn);
+            // RK: A = q.(x-r0)/||x-r0||^3
+            const Vect3& r = x-r0;
+            const double rn2 = r.norm2();
+            return dotprod(q,r)/(rn2*sqrt(rn2));
         }
+
+    private:
+
+        Vect3 r0;
+        Vect3 q;
     };
 
-    class OPENMEEG_EXPORT analyticDipPotDer
-    {
-        Vect3 q, r0;
-        Vect3 H0, H1, H2;
-        Vect3 H0p0DivNorm2, H1p1DivNorm2, H2p2DivNorm2, n;
-
+    class OPENMEEG_EXPORT analyticDipPotDer {
     public:
-        analyticDipPotDer(){}
+
+         analyticDipPotDer(){}
         ~analyticDipPotDer(){}
-        inline void init( const Triangle& T, const Vect3 &_q, const Vect3& _r0) {
+
+        void init( const Triangle& T, const Vect3 &_q, const Vect3& _r0) {
             q = _q;
             r0 = _r0;
 
-            Vect3 p0, p1, p2, p1p0, p2p1, p0p2, p1p0n, p2p1n, p0p2n, p1H0, p2H1, p0H2;
-            p0 = T.s1();
-            p1 = T.s2();
-            p2 = T.s3();
+            const Vect3& p0 = T.vertex(0);
+            const Vect3& p1 = T.vertex(1);
+            const Vect3& p2 = T.vertex(2);
 
-            p1p0 = p0-p1; p2p1 = p1-p2; p0p2 = p2-p0;
-            p1p0n = p1p0; p1p0n.normalize(); p2p1n = p2p1; p2p1n.normalize(); p0p2n = p0p2; p0p2n.normalize();
+            const Vect3& p1p0 = p0-p1;
+            const Vect3& p2p1 = p1-p2;
+            const Vect3& p0p2 = p2-p0;
+            const Vect3& p1p0n = p1p0/p1p0.norm();
+            const Vect3& p2p1n = p2p1/p2p1.norm();
+            const Vect3& p0p2n = p0p2/p0p2.norm();
 
-            p1H0 = (p1p0*p2p1n)*p2p1n; H0 = p1H0+p1; H0p0DivNorm2 = p0-H0; H0p0DivNorm2 = H0p0DivNorm2/H0p0DivNorm2.norm2();
-            p2H1 = (p2p1*p0p2n)*p0p2n; H1 = p2H1+p2; H1p1DivNorm2 = p1-H1; H1p1DivNorm2 = H1p1DivNorm2/H1p1DivNorm2.norm2();
-            p0H2 = (p0p2*p1p0n)*p1p0n; H2 = p0H2+p0; H2p2DivNorm2 = p2-H2; H2p2DivNorm2 = H2p2DivNorm2/H2p2DivNorm2.norm2();
+            const Vect3& p1H0 = dotprod(p1p0,p2p1n)*p2p1n;
+            H0 = p1H0+p1;
+            H0p0DivNorm2 = p0-H0;
+            H0p0DivNorm2 = H0p0DivNorm2/H0p0DivNorm2.norm2();
+            const Vect3& p2H1 = dotprod(p2p1,p0p2n)*p0p2n;
+            H1 = p2H1+p2;
+            H1p1DivNorm2 = p1-H1;
+            H1p1DivNorm2 = H1p1DivNorm2/H1p1DivNorm2.norm2();
+            const Vect3& p0H2 = dotprod(p0p2,p1p0n)*p1p0n;
+            H2 = p0H2+p0;
+            H2p2DivNorm2 = p2-H2;
+            H2p2DivNorm2 = H2p2DivNorm2/H2p2DivNorm2.norm2();
 
-            n = -p1p0^p0p2;
+            n = -crossprod(p1p0,p0p2);
             n.normalize();
         }
 
-        inline Vect3 f(const Vect3& x) const
-        {
-            Vect3 P1part(H0p0DivNorm2*(x-H0), H1p1DivNorm2*(x-H1), H2p2DivNorm2*(x-H2));
+        Vect3 f(const Vect3& x) const {
+            Vect3 P1part(dotprod(H0p0DivNorm2,x-H0),dotprod(H1p1DivNorm2,x-H1),dotprod(H2p2DivNorm2,x-H2));
 
             // RK: B = n.grad_x(A) with grad_x(A)= q/||^3 - 3r(q.r)/||^5
-            Vect3 r = x-r0;
-            double rn = r.norm();
-            double EMpart = n*(q/pow(rn, 3.)-3*(q*r)*r/pow(rn, 5.));
+            const Vect3& r   = x-r0;
+            const double rn2 = r.norm2();
+            const double EMpart = dotprod(n,q-3*dotprod(q,r)*r/rn2)/(rn2*sqrt(rn2));
 
             return -EMpart*P1part; // RK: why - sign ?
         }
+
+    private:
+
+        Vect3 q, r0;
+        Vect3 H0, H1, H2;
+        Vect3 H0p0DivNorm2, H1p1DivNorm2, H2p2DivNorm2, n;
     };
 }

--- a/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/include/assemble.h
@@ -49,87 +49,90 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 namespace OpenMEEG {
 
-    class OPENMEEG_EXPORT HeadMat: public virtual SymMatrix {
+    class OPENMEEG_EXPORT HeadMat: public SymMatrix {
     public:
-        HeadMat (const Geometry& geo, const unsigned gauss_order=3);
-        virtual ~HeadMat () {};
+        HeadMat(const Geometry& geo,const unsigned gauss_order=3);
+        virtual ~HeadMat() { };
     };
 
-    class OPENMEEG_EXPORT SurfSourceMat: public virtual Matrix {
+    class OPENMEEG_EXPORT SurfSourceMat: public Matrix {
     public:
-        SurfSourceMat (const Geometry& geo, Mesh& sources, const unsigned gauss_order=3);
-        virtual ~SurfSourceMat () {};
+        SurfSourceMat(const Geometry& geo,Mesh& sources,const unsigned gauss_order=3);
+        virtual ~SurfSourceMat() { };
     };
 
-    class OPENMEEG_EXPORT DipSourceMat: public virtual Matrix {
+    class OPENMEEG_EXPORT DipSourceMat: public Matrix {
     public:
-        DipSourceMat (const Geometry& geo, const Matrix& dipoles, const unsigned gauss_order=3,
-                      const bool adapt_rhs = true, const std::string& domain_name = "");
-        virtual ~DipSourceMat () {};
+        DipSourceMat(const Geometry& geo,const Matrix& dipoles,const unsigned gauss_order=3,
+                     const bool adapt_rhs=true,const std::string& domain_name="");
+        virtual ~DipSourceMat() { };
     };
 
-    class OPENMEEG_EXPORT EITSourceMat: public virtual Matrix {
+    class OPENMEEG_EXPORT EITSourceMat: public Matrix {
     public:
-        EITSourceMat(const Geometry& geo, const Sensors& electrodes, const unsigned gauss_order=3);
-        virtual ~EITSourceMat () {};
+        EITSourceMat(const Geometry& geo,const Sensors& electrodes,const unsigned gauss_order=3);
+        virtual ~EITSourceMat() { }
     };
 
-    class OPENMEEG_EXPORT Surf2VolMat: public virtual Matrix {
+    class OPENMEEG_EXPORT Surf2VolMat: public Matrix {
     public:
         using Matrix::operator=;
-        Surf2VolMat(const Geometry& geo, const Matrix& points);
-        virtual ~Surf2VolMat () {};
+        Surf2VolMat(const Geometry& geo,const Matrix& points);
+        virtual ~Surf2VolMat() { }
     };
 
-    class OPENMEEG_EXPORT Head2EEGMat: public virtual SparseMatrix {
+    class OPENMEEG_EXPORT Head2EEGMat: public SparseMatrix {
     public:
-        Head2EEGMat (const Geometry& geo, const Sensors& electrodes);
-        virtual ~Head2EEGMat () {};
+        Head2EEGMat(const Geometry& geo,const Sensors& electrodes);
+        virtual ~Head2EEGMat() { }
     };
 
-    class OPENMEEG_EXPORT Head2ECoGMat: public virtual SparseMatrix {
+    class OPENMEEG_EXPORT Head2ECoGMat: public SparseMatrix {
     public:
-        Head2ECoGMat (const Geometry& geo, const Sensors& electrodes, const Interface& i);
-        Head2ECoGMat (const Geometry& geo, const Sensors& electrodes, const std::string& id); // mainly for SWIG
-        virtual ~Head2ECoGMat () {};
+        Head2ECoGMat(const Geometry& geo,const Sensors& electrodes,const Interface& i);
+        // Mainly for SWIG
+        Head2ECoGMat(const Geometry& geo,const Sensors& electrodes,const std::string& id):
+            Head2ECoGMat(geo,electrodes,geo.interface(id)) { }
+
+        virtual ~Head2ECoGMat() { }
     };
 
-    class OPENMEEG_EXPORT Head2MEGMat: public virtual Matrix {
+    class OPENMEEG_EXPORT Head2MEGMat: public Matrix {
     public:
-        Head2MEGMat (const Geometry& geo, const Sensors& sensors);
-        virtual ~Head2MEGMat () {};
+        Head2MEGMat(const Geometry& geo,const Sensors& sensors);
+        virtual ~Head2MEGMat() { }
     };
 
-    class OPENMEEG_EXPORT SurfSource2MEGMat: public virtual Matrix {
+    class OPENMEEG_EXPORT SurfSource2MEGMat: public Matrix {
     public:
-        SurfSource2MEGMat (const Mesh& sources, const Sensors& sensors);
-        virtual ~SurfSource2MEGMat () {};
+        SurfSource2MEGMat(const Mesh& sources,const Sensors& sensors);
+        virtual ~SurfSource2MEGMat() { }
     };
 
-    class OPENMEEG_EXPORT DipSource2MEGMat: public virtual Matrix {
+    class OPENMEEG_EXPORT DipSource2MEGMat: public Matrix {
     public:
-        DipSource2MEGMat(const Matrix& dipoles, const Sensors& sensors);
-        virtual ~DipSource2MEGMat () {};
+        DipSource2MEGMat(const Matrix& dipoles,const Sensors& sensors);
+        virtual ~DipSource2MEGMat() { }
     };
 
-    class OPENMEEG_EXPORT DipSource2InternalPotMat: public virtual Matrix {
+    class OPENMEEG_EXPORT DipSource2InternalPotMat: public Matrix {
     public:
-        DipSource2InternalPotMat(const Geometry& geo, const Matrix& dipoles,
-                                 const Matrix& points, const std::string& domain_name = "");
-        virtual ~DipSource2InternalPotMat () {};
+        DipSource2InternalPotMat(const Geometry& geo,const Matrix& dipoles,
+                                 const Matrix& points,const std::string& domain_name = "");
+        virtual ~DipSource2InternalPotMat() { }
     };
 
-    class OPENMEEG_EXPORT CorticalMat: public virtual Matrix {
+    class OPENMEEG_EXPORT CorticalMat: public Matrix {
     public:
-        CorticalMat (const Geometry& geo, const Head2EEGMat& M, const std::string& domain_name = "CORTEX",
-                const unsigned gauss_order=3, double alpha=-1., double beta=-1., const std::string &filename="");
-        virtual ~CorticalMat () {};
+        CorticalMat(const Geometry& geo,const Head2EEGMat& M,const std::string& domain_name="CORTEX",
+                const unsigned gauss_order=3,double alpha=-1.,double beta=-1.,const std::string &filename="");
+        virtual ~CorticalMat() { }
     };
 
-    class OPENMEEG_EXPORT CorticalMat2: public virtual Matrix {
+    class OPENMEEG_EXPORT CorticalMat2: public Matrix {
     public:
-        CorticalMat2(const Geometry& geo, const Head2EEGMat& M, const std::string& domain_name = "CORTEX",
-                const unsigned gauss_order=3, double gamma=1., const std::string &filename="");
-        virtual ~CorticalMat2() {};
+        CorticalMat2(const Geometry& geo,const Head2EEGMat& M,const std::string& domain_name="CORTEX",
+                const unsigned gauss_order=3,double gamma=1.,const std::string &filename="");
+        virtual ~CorticalMat2() { }
     };
 }

--- a/OpenMEEG/include/edge.h
+++ b/OpenMEEG/include/edge.h
@@ -50,9 +50,10 @@ namespace OpenMEEG {
     class OPENMEEG_EXPORT Edge {
     public:
 
-        #ifdef SWIG_VERSION
-        Edge() { }
-        #endif
+        Edge() {
+            vertices[0] = nullptr;
+            vertices[1] = nullptr;
+        }
 
         Edge(const Vertex& V1,const Vertex& V2) {
             vertices[0] = &V1;
@@ -60,6 +61,9 @@ namespace OpenMEEG {
         }
 
         const Vertex& vertex(const unsigned i) const { return *vertices[i]; }
+
+        bool operator==(const Edge& e) const { return (e.vertex(0)==vertex(0)) && (e.vertex(1)==vertex(1)); }
+        bool operator!=(const Edge& e) const { return (e.vertex(0)!=vertex(0)) || (e.vertex(1)!=vertex(1)); }
 
     private:
 

--- a/OpenMEEG/include/edge.h
+++ b/OpenMEEG/include/edge.h
@@ -1,0 +1,70 @@
+/*
+Project Name : OpenMEEG
+
+© INRIA and ENPC (contributors: Geoffray ADDE, Maureen CLERC, Alexandre
+GRAMFORT, Renaud KERIVEN, Jan KYBIC, Perrine LANDREAU, Théodore PAPADOPOULO,
+Emmanuel OLIVI
+Maureen.Clerc.AT.inria.fr, keriven.AT.certis.enpc.fr,
+kybic.AT.fel.cvut.cz, papadop.AT.inria.fr)
+
+The OpenMEEG software is a C++ package for solving the forward/inverse
+problems of electroencephalography and magnetoencephalography.
+
+This software is governed by the CeCILL-B license under French law and
+abiding by the rules of distribution of free software.  You can  use,
+modify and/ or redistribute the software under the terms of the CeCILL-B
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info".
+
+As a counterpart to the access to the source code and  rights to copy,
+modify and redistribute granted by the license, users are provided only
+with a limited warranty  and the software's authors,  the holders of the
+economic rights,  and the successive licensors  have only  limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading,  using,  modifying and/or developing or reproducing the
+software by the user in light of its specific status of free software,
+that may mean  that it is complicated to manipulate,  and  that  also
+therefore means  that it is reserved for developers  and  experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and,  more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL-B license and that you accept its terms.
+*/
+
+#pragma once
+
+#include <vector>
+#include <vertex.h>
+
+namespace OpenMEEG {
+
+    /// \brief Edge
+    /// Edge class
+
+    class OPENMEEG_EXPORT Edge {
+    public:
+
+        #ifdef SWIG_VERSION
+        Edge() { }
+        #endif
+
+        Edge(const Vertex& V1,const Vertex& V2) {
+            vertices[0] = &V1;
+            vertices[1] = &V2;
+        }
+
+        const Vertex& vertex(const unsigned i) const { return *vertices[i]; }
+
+    private:
+
+        const Vertex* vertices[2];
+    };
+
+    typedef std::vector<Edge> Edges;
+}

--- a/OpenMEEG/include/gain.h
+++ b/OpenMEEG/include/gain.h
@@ -97,8 +97,8 @@ namespace OpenMEEG {
                 HeadMat.solveLin(mtemp); // solving the system AX=B with LAPACK
                 mtemp=mtemp.transpose();
                 #endif
-                for ( unsigned i = 0; i < LeadField.ncol(); ++i) {
-                    LeadField.setcol(i,mtemp * DipSourceMat(geo, dipoles.submat(i, 1, 0, dipoles.ncol()), gauss_order, true, "").getcol(0)); // TODO ugly
+                for (unsigned i=0;i<LeadField.ncol();++i) {
+                    LeadField.setcol(i,mtemp*DipSourceMat(geo,dipoles.submat(i,1,0,dipoles.ncol()),gauss_order,true,"").getcol(0)); // TODO ugly
                     PROGRESSBAR(i,LeadField.ncol());
                 }
                 *this = LeadField;
@@ -137,7 +137,7 @@ namespace OpenMEEG {
                 mtemp=mtemp.transpose();
                 #endif
                 for (unsigned i=0;i<LeadField.ncol();i++) {
-                    LeadField.setcol(i, mtemp * DipSourceMat(geo, dipoles.submat(i, 1, 0, dipoles.ncol()), gauss_order, true, "").getcol(0)+Source2MEGMat.getcol(i)); // TODO ugly
+                    LeadField.setcol(i,mtemp*DipSourceMat(geo,dipoles.submat(i,1,0,dipoles.ncol()),gauss_order,true,"").getcol(0)+Source2MEGMat.getcol(i)); // TODO ugly
                     PROGRESSBAR(i,LeadField.ncol());
                 }
                 *this = LeadField;

--- a/OpenMEEG/include/geometry_io.h
+++ b/OpenMEEG/include/geometry_io.h
@@ -176,67 +176,75 @@ namespace OpenMEEG {
         cell_indices->SetName("Indices");
         point_indices->SetName("Indices");
 
-        if (data.nlin() != 0) {
+        if (data.nlin()!=0) {
             // Check the data corresponds to the geometry
-            bool HAS_OUTERMOST = false; // data has last p values ?
-            if (data.nlin() == size()) {
-                HAS_OUTERMOST = true;
-            } else {
-                om_error(data.nlin() == size()-outermost_interface().nb_triangles());
-            }
+
+            const bool HAS_OUTERMOST = (data.nlin()==size()); // data has least p values ?
+            if (!HAS_OUTERMOST)
+                om_error(data.nlin()==size()-outermost_interface().nb_triangles());
+
             for (unsigned j = 0; j < data.ncol(); ++j) {
                 std::stringstream sdip;
                 sdip << j;
+
                 potentials[j] = vtkSmartPointer<vtkDoubleArray>::New();
-                currents[j]   = vtkSmartPointer<vtkDoubleArray>::New();
                 potentials[j]->SetName(("Potentials-"+sdip.str()).c_str());
+
+                currents[j]   = vtkSmartPointer<vtkDoubleArray>::New();
                 currents[j]->SetName(("Currents-"+sdip.str()).c_str());
 
-                for (Vertices::const_iterator vit = vertex_begin(); vit != vertex_end(); ++vit) {
-                    potentials[j]->InsertNextValue(data(vit->index(), j));
-                }
+                for (const auto& vertex : vertices())
+                    potentials[j]->InsertNextValue(data(vertex.index(),j));
 
-                for (Meshes::const_iterator mit = meshes_.begin(); mit != meshes_.end(); ++mit) {
-                    for (Mesh::const_iterator tit = mit->begin(); tit != mit->end(); ++tit) {
-                        currents[j]->InsertNextValue(((mit->outermost() && !HAS_OUTERMOST) ? 0.0 : data(tit->index(), j)));
-                    }
-                }
+                for(const auto& mesh : meshes_)
+                    for (const auto& triangle: mesh.triangles())
+                        currents[j]->InsertNextValue(((mesh.outermost() && !HAS_OUTERMOST) ? 0.0 : data(triangle.index(),j)));
             }
         }
 
         std::map<const Vertex*, unsigned> map;
 
         unsigned i = 0;
-        for (Vertices::const_iterator vit = vertex_begin(); vit != vertex_end(); ++vit, ++i) {
-            points->InsertNextPoint((*vit)(0), (*vit)(1), (*vit)(2));
-            point_indices->InsertNextValue(vit->index());
-            map[&*vit] = i;
+        for (const auto& vertex : vertices()) {
+            points->InsertNextPoint(vertex(0), vertex(1), vertex(2));
+            point_indices->InsertNextValue(vertex.index());
+            map[&vertex] = i++;
         }
+
         // Add the vertices to polydata
+        
         polydata->SetPoints(points);
 
         vtkSmartPointer<vtkCellArray> polys  = vtkSmartPointer<vtkCellArray>::New(); // the triangles
 
-        for (Meshes::const_iterator mit = meshes_.begin(); mit != meshes_.end(); ++mit) {
-            for ( Mesh::const_iterator tit = mit->begin(); tit != mit->end(); ++tit) {
-                vtkIdType triangle[3] = { map[&(tit->s1())], map[&(tit->s2())], map[&(tit->s3())] };
-                polys->InsertNextCell(3, triangle);
-                cell_id->InsertNextValue(mit->name());
-                cell_indices->InsertNextValue(tit->index());
+        for(const auto& mesh : meshes_)
+            for (const auto& triangle: mesh.triangles()) {
+                const vtkIdType vtktriangle[3] = { map[&(triangle.vertex(0))], map[&(triangle.vertex(1))], map[&(triangle.vertex(2))] };
+                polys->InsertNextCell(3, vtktriangle);
+                cell_id->InsertNextValue(mesh.name());
+                cell_indices->InsertNextValue(triangle.index());
             }
-        }
 
         // Add the triangles to polydata
+
         polydata->SetPolys(polys);
+
         // Add the array of Names to polydata
+
         polydata->GetCellData()->AddArray(cell_id);
+
         // Add the array of Indices to polydata cells
+
         polydata->GetCellData()->AddArray(cell_indices);
+
         // Add the array of Indices to polydata points
+
         polydata->GetPointData()->AddArray(point_indices);
+
         // Add optional potentials and currents
-        if (data.nlin() != 0) {
-            for (unsigned j = 0; j < data.ncol(); ++j) {
+
+        if (data.nlin()!=0) {
+            for (unsigned j=0;j<data.ncol();++j) {
                 polydata->GetPointData()->AddArray(potentials[j]);
                 polydata->GetCellData()->AddArray(currents[j]);
             }

--- a/OpenMEEG/include/interface.h
+++ b/OpenMEEG/include/interface.h
@@ -50,13 +50,15 @@ knowledge of the CeCILL-B license and that you accept its terms.
 namespace OpenMEEG {
 
     /// An Oriented Mesh is a mesh associated with a boolean stating if it is well oriented. 
-    class OrientedMesh: public std::pair<Mesh *, bool> 
-    {
-        typedef std::pair<Mesh *, bool> base;
+
+    class OrientedMesh: public std::pair<Mesh*,bool> {
+
+        typedef std::pair<Mesh*,bool> base;
 
     public:
 
         ///default constructors
+
         OrientedMesh() {}
 
         OrientedMesh(Mesh& _mesh, bool _inside): base(&_mesh, _inside) {}
@@ -117,7 +119,7 @@ namespace OpenMEEG {
 
     private:
 
-        double compute_solid_angle(const Vect3& p) const; ///< Given a point p, it computes the solid angle \return should return +/- 4 PI or 0.
+        double solid_angle(const Vect3& p) const; ///< Given a point p, it computes the solid angle \return should return +/- 4 PI or 0.
 
         std::string name_;      ///< is "" by default
         bool        outermost_; ///< tell weather or not the interface touches the Air (Outermost) Domain.

--- a/OpenMEEG/include/om_utils.h
+++ b/OpenMEEG/include/om_utils.h
@@ -64,92 +64,84 @@ knowledge of the CeCILL-B license and that you accept its terms.
 namespace OpenMEEG {
 
     #ifndef M_PI
-        #define M_PI 3.14159265358979323846
+        constexpr double M_PI = 3.14159265358979323846;
     #endif
 
-    #define MU0 (4*M_PI*1e-7)
+    constexpr double MU0 = 4*M_PI*1e-7;
 
-    inline std::string getNameExtension ( const std::string& name )
-    {
-        std::string::size_type idx = name.find('.');
-        if (idx == std::string::npos) {
+    inline std::string getNameExtension(const std::string& name) {
+        const std::string::size_type idx = name.find('.');
+        if (idx==std::string::npos) {
             return std::string("");
-        } else if (name.substr(idx+1).find('.') != std::string::npos) {
-            return getNameExtension( name.substr(idx+1) );
+        } else if (name.substr(idx+1).find('.')!=std::string::npos) {
+            return getNameExtension(name.substr(idx+1));
         } else {
             return name.substr(idx+1);
         }
-    };
+    }
 
-    inline void init_random(int seed) {
+    inline void init_random(const int seed) {
         static bool first=true;
         if (seed==-1 && !first)
             return;
-        first=false;
+        first = false;
         // srand((unsigned int)((seed==-1)?time(0):seed));
         srand(0);
         rand(); // the first is biased!
     }
 
-    inline double drandom()
-    {
+    inline double drandom() {
         init_random(-1);
         return double(rand())/RAND_MAX;
     }
 
-    inline double gaussian()
-    {
-        double x;
-        do
-            x=drandom();
-        while (x==0);
-        return (double)(sqrt(-2*log(x))*cos(2*M_PI*drandom()));
+    inline double gaussian() {
+        double x = 0.0;
+        while (x==0)
+            x = drandom();
+        return static_cast<double>(sqrt(-2*log(x))*cos(2*M_PI*drandom()));
     }
 
-    inline void disp_argv(int argc, char **argv) {
+    inline void disp_argv(const int argc,char **argv) {
         std::cout << std::endl << "| ------ " << argv[0] << std::endl;
-        for( int i = 1; i < argc; i += 1 )
-        {
+        for (int i=1;i<argc;++i)
             std::cout << "| " << argv[i] << std::endl;
-        }
         std::cout << "| -----------------------" << std::endl;
     }
 
 #ifdef USE_PROGRESSBAR
-    inline void progressbar(unsigned n, unsigned N, unsigned w = 20) {
+    inline void progressbar(const unsigned n,const unsigned N,const unsigned w=20) {
         // w : nb of steps
-        const char* cprog = ".";
-        const char* cprog1 = "*";
-        const char* cbeg = "[";
-        const char* cend = "]";
-        unsigned p = (unsigned)std::min( (unsigned)floor(1.f*n*(w+1)/N), w);
+        const char cprog  = '.';
+        const char cprog1 = '*';
+        const char cbeg   = '[';
+        const char cend   = ']';
+        const unsigned p = std::min(static_cast<unsigned>(floor(1.f*n*(w+1)/N)),w);
 
         static unsigned pprev = -1;
         if (N>1) {
-            if (n == 0) {
+            if (n==0)
                 pprev = -1;
-            }
 
-            if (p != pprev) {
+            if (p!=pprev) {
                 if (n>1) {
                     // clear previous string
-                    for(unsigned i = 0; i < (w+2); ++i)
-                        std::cout<< "\b";
+                    for (unsigned i=0;i<(w+2);++i)
+                        std::cout << "\b";
 
-                    std::cout<< cbeg;
-                    for(unsigned i = 0; i < p; ++i) {
-                        std::cout<< cprog1;
-                    }
-                    for(unsigned i = p; i < w; ++i) {
-                        std::cout<< cprog;
-                    }
+                    std::cout << cbeg;
+                    for (unsigned i=0;i<p;++i)
+                        std::cout << cprog1;
+
+                    for (unsigned i=p;i<w;++i)
+                        std::cout << cprog;
+
                     std::cout<< cend;
                 }
             }
             pprev = p;
-            if (n >= (N-1)) {
-                std::cout<<"\n";
-            }
+            if (n>=(N-1))
+                std::cout << std::endl;
             std::cout.flush();
         }
     }

--- a/OpenMEEG/include/operators.h
+++ b/OpenMEEG/include/operators.h
@@ -73,7 +73,7 @@ namespace OpenMEEG {
         gauss->setOrder(gauss_order);
 
         #pragma omp parallel for
-        for (const auto& triangle : m) {
+        for (const auto& triangle : m.triangles()) {
             double d = gauss->integrate(anaDP,triangle);
             #pragma omp critical
             rhs(triangle.index()) += d*coeff;

--- a/OpenMEEG/include/triangle.h
+++ b/OpenMEEG/include/triangle.h
@@ -92,7 +92,7 @@ namespace OpenMEEG {
               Vertex&   operator()(const unsigned& vindex)       { return *vertices_[vindex]; }
         const Vertex&   operator()(const unsigned& vindex) const { return *vertices_[vindex]; }
 
-              bool      operator==(const Triangle& T)     const { return (T[0]==vertices_[0])&(T[1]==vertices_[1])&(T[2]==vertices_[2]); }
+              bool      operator==(const Triangle& T)     const { return (T[0]==(*this)[0]) && (T[1]==(*this)[1]) && (T[2]==(*this)[2]); }
                                                  
               Vertex&        vertex(const unsigned& vindex)       { return operator()(vindex); }
         const Vertex&        vertex(const unsigned& vindex) const { return operator()(vindex); }

--- a/OpenMEEG/include/triangle.h
+++ b/OpenMEEG/include/triangle.h
@@ -85,12 +85,12 @@ namespace OpenMEEG {
         }
         
         /// Operators
-        // Having both [] and () doing different things is prone to errors. Also the %3 in indexing seems vety costly.
+        // Having both [] and () doing different things is prone to errors.
 
-              Vertex*   operator[](const unsigned& vindex)       { return vertices_[vindex%3];  } // 0 <= 'index' <= '2'
-        const Vertex*   operator[](const unsigned& vindex) const { return vertices_[vindex%3];  }
-              Vertex&   operator()(const unsigned& vindex)       { return *vertices_[vindex%3]; } // 0 <= 'index' <= '2'
-        const Vertex&   operator()(const unsigned& vindex) const { return *vertices_[vindex%3]; }
+              Vertex*   operator[](const unsigned& vindex)       { return vertices_[vindex];  }
+        const Vertex*   operator[](const unsigned& vindex) const { return vertices_[vindex];  }
+              Vertex&   operator()(const unsigned& vindex)       { return *vertices_[vindex]; }
+        const Vertex&   operator()(const unsigned& vindex) const { return *vertices_[vindex]; }
 
               bool      operator==(const Triangle& T)     const { return (T[0]==vertices_[0])&(T[1]==vertices_[1])&(T[2]==vertices_[2]); }
                                                  

--- a/OpenMEEG/include/vect3.h
+++ b/OpenMEEG/include/vect3.h
@@ -53,11 +53,9 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 namespace OpenMEEG {
 
-    /** \brief  Vect3
+    inline double sqr(const double& x) { return x*x; }
 
-        Mesh Class
-
-    **/
+    /// \brief  Vect3
 
     class OPENMEEG_EXPORT Vect3 {
 
@@ -65,90 +63,91 @@ namespace OpenMEEG {
 
     public:
 
-        inline  Vect3() { }
-        inline  Vect3(const double& xx, const double& yy, const double& zz) { m[0] = xx; m[1] = yy; m[2] = zz; }
-        inline  Vect3(const double& a) { std::fill(&m[0], &m[3], a); }
-        inline ~Vect3() { }
+        Vect3() { }
+        Vect3(const double& x1,const double& x2,const double& x3) { m[0] = x1; m[1] = x2; m[2] = x3; }
+        Vect3(const double& a) { std::fill(&m[0],&m[3],a); }
+        ~Vect3() { }
 
         Vect3& operator=(const Vect3& v) {
-            std::copy(&v.m[0], &v.m[3], &m[0]);
+            std::copy(&v.m[0],&v.m[3],&m[0]);
             return *this;
         }
 
         Vect3(const Vect3& v) {
-            m[0] = v.x();
-            m[1] = v.y();
-            m[2] = v.z();
+            for (unsigned i=0;i<3;++i)
+                m[i] = v.m[i];
         }
 
-        inline       double& x()       { return m[0]; }
-        inline const double& x() const { return m[0]; }
+              double& x()       { return m[0]; }
+        const double& x() const { return m[0]; }
 
-        inline       double& y()       { return m[1]; }
-        inline const double& y() const { return m[1]; }
+              double& y()       { return m[1]; }
+        const double& y() const { return m[1]; }
 
-        inline       double& z()       { return m[2]; }
-        inline const double& z() const { return m[2]; }
+              double& z()       { return m[2]; }
+        const double& z() const { return m[2]; }
 
-        inline double operator*(const Vect3& v) const { return m[0]*v.x()+m[1]*v.y()+m[2]*v.z(); }
-        inline double operator<(const Vect3& v) const { return ((m[0] != v.x())?(m[0] < v.x()):((m[1] != v.y())? (m[1] < v.y()):(m[2] < v.z()))); }
+        double operator<(const Vect3& v) const { return ((m[0]!=v.x()) ? (m[0]<v.x()) : ((m[1]!=v.y()) ? (m[1]<v.y()) : (m[2]<v.z()))); }
 
-        inline double norm()  const { return sqrt(norm2()); }
-        inline double norm2() const { return m[0]*m[0]+m[1]*m[1]+m[2]*m[2]; }
+        double norm()  const { return sqrt(norm2());                 }
+        double norm2() const { return sqr(m[0])+sqr(m[1])+sqr(m[2]); }
 
-        inline bool operator==(const Vect3& v ) const { return (m[0]==v.x() && m[1]==v.y() && m[2]==v.z()); }
-        inline bool operator!=(const Vect3& v ) const { return (m[0]!=v.x() || m[1]!=v.y() || m[2]!=v.z()); }
+        bool operator==(const Vect3& v ) const { return (m[0]==v.x() && m[1]==v.y() && m[2]==v.z()); }
+        bool operator!=(const Vect3& v ) const { return (m[0]!=v.x() || m[1]!=v.y() || m[2]!=v.z()); }
 
-        inline void operator+=(const Vect3& v)  { m[0] += v.x(); m[1] += v.y(); m[2] += v.z(); }
-        inline void operator-=(const Vect3& v)  { m[0] -= v.x(); m[1] -= v.y(); m[2] -= v.z(); }
-        inline void operator*=(const double& d) { m[0] *= d; m[1] *= d; m[2] *= d; }
-        inline void operator/=(const double& d) { operator*=(1.0/d); }
+        void operator+=(const Vect3& v)  { m[0] += v.x(); m[1] += v.y(); m[2] += v.z(); }
+        void operator-=(const Vect3& v)  { m[0] -= v.x(); m[1] -= v.y(); m[2] -= v.z(); }
+        void operator*=(const double& d) { m[0] *= d; m[1] *= d; m[2] *= d; }
+        void operator/=(const double& d) { operator*=(1.0/d); }
 
-        inline void multadd(const double& d, const Vect3& v) {m[0] += d*v.x(); m[1] += d*v.y(); m[2] += d*v.z();}
+        void multadd(const double& d, const Vect3& v) {m[0] += d*v.x(); m[1] += d*v.y(); m[2] += d*v.z();}
 
-        inline Vect3 operator+(const Vect3& v)  const { return Vect3(m[0]+v.x(), m[1]+v.y(), m[2]+v.z()); }
-        inline Vect3 operator-(const Vect3& v)  const { return Vect3(m[0]-v.x(), m[1]-v.y(), m[2]-v.z()); }
-        inline Vect3 operator^(const Vect3& v)  const { return Vect3(m[1]*v.z()-m[2]*v.y(), m[2]*v.x()-m[0]*v.z(), m[0]*v.y()-m[1]*v.x()); }
-        inline Vect3 operator*(const double& d) const { return Vect3(d*m[0], d*m[1], d*m[2]); }
-        inline Vect3 operator/(const double& d) const { return Vect3(m[0]/d, m[1]/d, m[2]/d); }
+        Vect3 operator+(const Vect3& v)  const { return Vect3(m[0]+v.x(),m[1]+v.y(),m[2]+v.z()); }
+        Vect3 operator-(const Vect3& v)  const { return Vect3(m[0]-v.x(),m[1]-v.y(),m[2]-v.z()); }
+        Vect3 operator^(const Vect3& v)  const { return Vect3(m[1]*v.z()-m[2]*v.y(),m[2]*v.x()-m[0]*v.z(),m[0]*v.y()-m[1]*v.x()); }
+        Vect3 operator*(const double& d) const { return Vect3(d*m[0],d*m[1],d*m[2]); }
+        Vect3 operator/(const double& d) const { return Vect3(m[0]/d,m[1]/d,m[2]/d); }
 
-        inline double operator() (const int i) const {
+        double operator()(const int i) const {
             om_assert(i>=0 && i<3);
             return m[i];
         }
 
-        inline double& operator()(const int i) {
+        double& operator()(const int i) {
             om_assert(i>=0 && i<3);
             return m[i];
         }
 
-        inline Vect3 operator-() { return Vect3(-m[0], -m[1], -m[2]); }
+        Vect3 operator-() const { return Vect3(-m[0],-m[1],-m[2]); }
 
-        inline double det(const Vect3& y2, const Vect3& y3) const {
-            return (*this)*(y2^y3); // y1.det(y2, y3):= y1/(y2^y3)
-        }
+        inline double solid_angle(const Vect3& v1,const Vect3& v2,const Vect3& v3) const;
 
-        inline double solangl(const Vect3& v1, const Vect3& v2, const Vect3& v3) const {
-            // De Munck : Good sign directly
-            const Vect3 Y1 = v1 - *this;
-            const Vect3 Y2 = v2 - *this;
-            const Vect3 Y3 = v3 - *this;
-            const double y1 = Y1.norm();
-            const double y2 = Y2.norm();
-            const double y3 = Y3.norm();
-            const double d = Y1*(Y2^Y3);
-            return 2.*atan2(d, (y1*y2*y3+y1*(Y2*Y3)+y2*(Y3*Y1)+y3*(Y1*Y2)));
-        }
-
-        inline void normalize() {
+        Vect3& normalize() {
             *this /= (*this).norm();
+            return *this;
         }
 
         friend std::ostream& operator<<(std::ostream& os, const Vect3& v);
         friend std::istream& operator>>(std::istream& is, Vect3& v);
     };
 
-    inline Vect3 operator*(const double& d, const Vect3& v) { return v*d; }
+    inline Vect3  operator*(const double& d,const Vect3& V)  { return V*d;   }
+    inline double dotprod(const Vect3& V1,const Vect3& V2)   { return V1.x()*V2.x()+V1.y()*V2.y()+V1.z()*V2.z(); }
+    inline Vect3  crossprod(const Vect3& V1,const Vect3& V2) { return V1^V2; }
+    inline double det(const Vect3& V1,const Vect3& V2,const Vect3& V3) { return dotprod(V1,crossprod(V2,V3)); }
+
+    inline double Vect3::solid_angle(const Vect3& V1,const Vect3& V2,const Vect3& V3) const {
+        // De Munck : Good sign directly
+        const Vect3& V0 = *this;
+        const Vect3& Y1 = V1-V0;
+        const Vect3& Y2 = V2-V0;
+        const Vect3& Y3 = V3-V0;
+        const double y1 = Y1.norm();
+        const double y2 = Y2.norm();
+        const double y3 = Y3.norm();
+        const double d = det(Y1,Y2,Y3);
+        return (fabs(d)<1e-10) ? 0.0 : 2*atan2(d,(y1*y2*y3+y1*dotprod(Y2,Y3)+y2*dotprod(Y3,Y1)+y3*dotprod(Y1,Y2)));
+    }
 
     inline std::istream& operator>>(std::istream& is, Vect3& v) {
         return is >> v.x() >> v.y() >> v.z();

--- a/OpenMEEG/src/assembleSourceMat.cpp
+++ b/OpenMEEG/src/assembleSourceMat.cpp
@@ -52,48 +52,54 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 namespace OpenMEEG {
 
-    void assemble_SurfSourceMat(Matrix& mat, const Geometry& geo, Mesh& mesh_source, const unsigned gauss_order) 
-    {
-        mat = Matrix((geo.size()-geo.nb_current_barrier_triangles()), mesh_source.nb_vertices());
+    SurfSourceMat::SurfSourceMat(const Geometry& geo,Mesh& source_mesh,const unsigned gauss_order) {
+
+        Matrix& mat = *this;
+
+        mat = Matrix((geo.size()-geo.nb_current_barrier_triangles()),source_mesh.nb_vertices());
         mat.set(0.0);
 
-        // check if no overlapping between the geometry and the source mesh
-        bool OK = geo.check(mesh_source);
-        if ( !OK ) {
+        // Check that there is no overlapping between the geometry and the source mesh.
+
+        if (!geo.check(source_mesh)) {
             std::cerr << "Error: source mesh overlapps the geometry" << std::endl;
             return;
-        } // then the mesh is included in a domain of the geometry
+        }
 
-        const Domain d     = geo.domain(**mesh_source.vertex_begin()); 
-        const double sigma = d.sigma();
-        const double K     = 1.0/(4.*M_PI);
+        // The mesh is included in a domain of the geometry.
+
+        const Domain& domain = geo.domain(**source_mesh.vertex_begin()); 
         
-        // We here set it as an outermost (to tell _operarorN it doesn't belong to the geometry)
-        mesh_source.outermost() = true;
-        mesh_source.current_barrier() = true;
+        // Set it as an outermost (to tell _operarorN it doesn't belong to the geometry).
 
-        std::cout << std::endl << "assemble SurfSourceMat with " << mesh_source.nb_vertices() << " mesh_source located in domain \"" << d.name() << "\"." << std::endl << std::endl;
+        source_mesh.outermost()       = true;
+        source_mesh.current_barrier() = true;
 
-        for ( Domain::const_iterator hit = d.begin(); hit != d.end(); ++hit) {
-            for ( Interface::const_iterator omit = hit->interface().begin(); omit != hit->interface().end(); ++omit) {
-                // First block is nVertexFistLayer*mesh_source.nb_vertices()
-                double coeffN = (hit->inside())?K * omit->orientation() : omit->orientation() * -K;
-                operatorN( omit->mesh(), mesh_source, mat, coeffN, gauss_order);
-                // Second block is nFacesFistLayer*mesh_source.nb_vertices()
-                double coeffD = (hit->inside())?-omit->orientation() * K / sigma : omit->orientation() * K / sigma;
-                operatorD(omit->mesh(), mesh_source, mat, coeffD, gauss_order,false);
+        std::cout << std::endl
+                  << "assemble SurfSourceMat with " << source_mesh.nb_vertices()
+                  << " source_mesh located in domain \"" << domain.name() << "\"." << std::endl
+                  << std::endl;
+
+        const double K  = 1.0/(4.*M_PI);
+        const double L  = -1.0/domain.sigma();
+        for (const auto& halfspace : domain) {
+            const double factorN = (halfspace.inside()) ? K : -K;
+            for (auto& oriented_mesh : halfspace.interface()) {
+                const Mesh& mesh = oriented_mesh.mesh();
+                // First block is nVertexFistLayer*source_mesh.nb_vertices()
+                const double coeffN = factorN*oriented_mesh.orientation();
+                operatorN(mesh,source_mesh,mat,coeffN,gauss_order);
+                // Second block is nFacesFistLayer*source_mesh.nb_vertices()
+                operatorD(mesh,source_mesh,mat,coeffN*L,gauss_order,false);
             }
         }
     }
 
-    SurfSourceMat::SurfSourceMat(const Geometry& geo, Mesh& mesh_source, const unsigned gauss_order) 
+    DipSourceMat::DipSourceMat(const Geometry& geo,const Matrix& dipoles,const unsigned gauss_order,
+                               const bool adapt_rhs,const std::string& domain_name)
     {
-        assemble_SurfSourceMat(*this, geo, mesh_source, gauss_order);
-    }
+        Matrix& rhs = *this;
 
-    void assemble_DipSourceMat(Matrix& rhs, const Geometry& geo, const Matrix& dipoles,
-            const unsigned gauss_order, const bool adapt_rhs, const std::string& domain_name = "") 
-    {
         const size_t size      = geo.size()-geo.nb_current_barrier_triangles();
         const size_t n_dipoles = dipoles.nlin();
 
@@ -114,17 +120,17 @@ namespace OpenMEEG {
             if (sigma!=0.0) {
                 rhs_col.set(0.0);
                 const double K = 1.0/(4.*M_PI);
-                //  Iterate over the domain's interfaces (half-spaces)
-                for (Domain::const_iterator hit=domain.begin(); hit!=domain.end(); ++hit) {
-                    //  Iterate over the meshes of the interface
-                    for (Interface::const_iterator omit=hit->interface().begin(); omit!=hit->interface().end(); ++omit) {
+                for (const auto& halfspace : domain) { //  Iterate over the domain's interfaces (half-spaces)
+                    const double factorD = (halfspace.inside()) ? K : -K;
+                    for (const auto& oriented_mesh : halfspace.interface()) { //  Iterate over the meshes of the interface
                         //  Treat the mesh.
-                        const double coeffD = ((hit->inside()) ? K : -K)*omit->orientation();
-                        operatorDipolePotDer(r,q,omit->mesh(),rhs_col,coeffD,gauss_order,adapt_rhs);
+                        const double coeffD = factorD*oriented_mesh.orientation();
+                        const Mesh&  mesh   = oriented_mesh.mesh();
+                        operatorDipolePotDer(r,q,mesh,rhs_col,coeffD,gauss_order,adapt_rhs);
 
-                        if (!omit->mesh().current_barrier()) {
+                        if (!oriented_mesh.mesh().current_barrier()) {
                             const double coeff = -coeffD/sigma;;
-                            operatorDipolePot(r,q,omit->mesh(),rhs_col,coeff,gauss_order,adapt_rhs);
+                            operatorDipolePot(r,q,mesh,rhs_col,coeff,gauss_order,adapt_rhs);
                         }
                     }
                 }
@@ -133,14 +139,9 @@ namespace OpenMEEG {
         }
     }
 
-    DipSourceMat::DipSourceMat(const Geometry& geo, const Matrix& dipoles, const unsigned gauss_order,
-                               const bool adapt_rhs, const std::string& domain_name)
-    {
-        assemble_DipSourceMat(*this, geo, dipoles, gauss_order, adapt_rhs, domain_name);
-    }
+    EITSourceMat::EITSourceMat(const Geometry& geo,const Sensors& electrodes,const unsigned gauss_order) {
+        Matrix& mat = *this;
 
-    void assemble_EITSourceMat(Matrix& mat, const Geometry& geo, const Sensors& electrodes, const unsigned gauss_order)
-    {
         //  A Matrix to be applied to the scalp-injected current to obtain the Source Term of the EIT foward problem.
         // following article BOUNDARY ELEMENT FORMULATION FOR ELECTRICAL IMPEDANCE TOMOGRAPHY
         // (eq.14 (do not look at eq.16 since there is a mistake: D_23 -> S_23))
@@ -191,21 +192,18 @@ namespace OpenMEEG {
         }
     }
 
-    EITSourceMat::EITSourceMat(const Geometry& geo, const Sensors& electrodes, const unsigned gauss_order) 
-    {
-        assemble_EITSourceMat(*this, geo, electrodes, gauss_order);
-    }
+    DipSource2InternalPotMat::DipSource2InternalPotMat(const Geometry& geo,const Matrix& dipoles,const Matrix& points,const std::string& domain_name) {
 
-    void assemble_DipSource2InternalPotMat(Matrix& mat, const Geometry& geo, const Matrix& dipoles,
-                                           const Matrix& points, const std::string& domain_name)     
-    {
+        Matrix& mat = *this;
+
         // Points with one more column for the index of the domain they belong
+
         std::vector<Domain> points_domain;
         std::vector<Vect3>  points_;
         for ( unsigned i = 0; i < points.nlin(); ++i) {
-            const Domain& d = geo.domain(Vect3(points(i, 0), points(i, 1), points(i, 2)));
-            if ( d.sigma() != 0.0 ) {
-                points_domain.push_back(d);
+            const Domain& domain = geo.domain(Vect3(points(i, 0), points(i, 1), points(i, 2)));
+            if ( domain.sigma() != 0.0 ) {
+                points_domain.push_back(domain);
                 points_.push_back(Vect3(points(i, 0), points(i, 1), points(i, 2)));
             }
             else {
@@ -237,11 +235,5 @@ namespace OpenMEEG {
                 }
             }
         }
-    }
-
-    DipSource2InternalPotMat::DipSource2InternalPotMat(const Geometry& geo, const Matrix& dipoles,
-                                                       const Matrix& points, const std::string& domain_name)
-    {
-        assemble_DipSource2InternalPotMat(*this, geo, dipoles, points, domain_name);
     }
 }

--- a/OpenMEEG/src/danielsson.cpp
+++ b/OpenMEEG/src/danielsson.cpp
@@ -61,25 +61,25 @@ namespace OpenMEEG
         }
         // Solves H=sum(alpha_i A_i), sum(alpha_i)=1, et HM.(A_i-A_0)=0
         Vect3 A0Ai[3]; // A_i-A_0
-        for ( unsigned i = 1; i < nb; ++i) {
-            A0Ai[i] = triangle.vertex(idx[i]) - triangle.vertex(idx[0]);
-        }
+        for (unsigned i=1;i<nb;++i)
+            A0Ai[i] = triangle.vertex(idx[i])-triangle.vertex(idx[0]);
+
         Vect3 A0M = p - triangle.vertex(idx[0]); // M-A_0
         if ( nb == 2 ) {
-            alphas(idx[1]) = (A0M * A0Ai[1]) / (A0Ai[1] * A0Ai[1]);
-            alphas(idx[0]) = 1.0 - alphas(idx[1]);
-        } else if ( nb == 3 ) {
+            alphas(idx[1]) = dotprod(A0M,A0Ai[1])/dotprod(A0Ai[1],A0Ai[1]);
+            alphas(idx[0]) = 1.0-alphas(idx[1]);
+        } else if (nb==3) {
             // direct inversion (2x2 linear system)
-            double a00 = A0Ai[1] * A0Ai[1];
-            double a10 = A0Ai[1] * A0Ai[2];
-            double a11 = A0Ai[2] * A0Ai[2];
-            double b0 = A0M * A0Ai[1];
-            double b1 = A0M * A0Ai[2];
-            double d = a00 * a11 - a10 * a10;
+            const double a00 = dotprod(A0Ai[1],A0Ai[1]);
+            const double a10 = dotprod(A0Ai[1],A0Ai[2]);
+            const double a11 = dotprod(A0Ai[2],A0Ai[2]);
+            const double b0 = dotprod(A0M,A0Ai[1]);
+            const double b1 = dotprod(A0M,A0Ai[2]);
+            const double d = a00*a11-a10*a10;
             om_error(d!=0);
-            alphas(idx[1]) = (b0 * a11 - b1 * a10) / d;
-            alphas(idx[2]) = (a00 * b1 - a10 * b0) / d;
-            alphas(idx[0]) = 1.0 - alphas(idx[1]) - alphas(idx[2]);
+            alphas(idx[1]) = (b0*a11-b1*a10)/d;
+            alphas(idx[2]) = (a00*b1-a10*b0)/d;
+            alphas(idx[0]) = 1.0-alphas(idx[1])-alphas(idx[2]);
         } else {
             // 3 unknowns or more -> solve system
             //  Ax=b with: A(i, j)=A0Ai.AjA0, x=(alpha_1, alpha_2, ...), b=A0M.A0Ai

--- a/OpenMEEG/src/geometry.cpp
+++ b/OpenMEEG/src/geometry.cpp
@@ -132,7 +132,7 @@ namespace OpenMEEG {
 
             for (const_iterator mit = begin(); mit != end(); ++mit) {
                 for (Mesh::const_iterator tit = mit->begin(); tit != mit->end(); ++tit) {
-                    std::cout << "[[" << tit->s1() << "] , [" << tit->s2() << "] , ["<< tit->s3() << "]] \t = " << tit->index() << std::endl;
+                    std::cout << "[[" << tit->vertex(0) << "] , [" << tit->vertex(1) << "] , ["<< tit->vertex(2) << "]] \t = " << tit->index() << std::endl;
                 }
             }
         }
@@ -429,14 +429,14 @@ namespace OpenMEEG {
         }
 
         // Copy the triangles in the geometry.
+
         iit = 0;
-        for (Meshes::const_iterator mit = m.begin(); mit != m.end(); ++mit, ++iit) {
-            for (Mesh::const_iterator tit = mit->begin(); tit != mit->end(); ++tit) {
-                meshes_[iit].push_back(Triangle(map_vertices[(*tit)[0]], 
-                                                map_vertices[(*tit)[1]],
-                                                map_vertices[(*tit)[2]]));
-            }
-            meshes_[iit].update();
+        for (const auto& mesh : m) {
+            for (const auto& triangle : mesh.triangles())
+                meshes_[iit].push_back(Triangle(map_vertices[&triangle.vertex(0)], 
+                                                map_vertices[&triangle.vertex(1)],
+                                                map_vertices[&triangle.vertex(2)]));
+            meshes_[iit++].update();
         }
     }
 
@@ -444,19 +444,20 @@ namespace OpenMEEG {
     void Geometry::mark_current_barrier() {
 
         // figure out the connectivity of meshes
+
         std::vector<int> mesh_idx;
-        for (unsigned i = 0; i < meshes().size(); i++) {
+        for (unsigned i=0;i<meshes().size();++i)
             mesh_idx.push_back(i);
-        }
-        std::vector<std::vector<int> > mesh_conn;
+
+        std::vector<std::vector<int>> mesh_conn;
         std::vector<int> mesh_connected, mesh_diff;
-        std::set_difference(mesh_idx.begin(), mesh_idx.end(), mesh_connected.begin(), mesh_connected.end(), std::insert_iterator<std::vector<int> >(mesh_diff, mesh_diff.end()));
+        std::set_difference(mesh_idx.begin(),mesh_idx.end(),mesh_connected.begin(),mesh_connected.end(),std::insert_iterator<std::vector<int>>(mesh_diff,mesh_diff.end()));
         while (!mesh_diff.empty()) {
             std::vector<int> conn;
-            int se = mesh_diff[0];
+            const int se = mesh_diff[0];
             conn.push_back(se);
             mesh_connected.push_back(se);
-            for (unsigned iit = 0; iit < conn.size(); ++iit) {
+            for (unsigned iit = 0;iit<conn.size();++iit) {
                 const Mesh& me = meshes()[conn[iit]];
                 for (Meshes::iterator mit = begin(); mit != end(); ++mit) {
                     if ( not almost_equal(sigma(me, *mit), 0.0)) {
@@ -478,7 +479,7 @@ namespace OpenMEEG {
         // find isolated meshes and touch 0-cond meshes;
         std::set<std::string> touch_0_mesh;
         for (Domains::iterator dit = domains_.begin(); dit != domains_.end(); ++dit) {
-            if ( almost_equal(dit->sigma(), 0.0)) {
+            if (almost_equal(dit->sigma(),0.0)) {
                 for (Domain::iterator hit = dit->begin(); hit != dit->end(); ++hit) {
                     for (Interface::iterator omit = hit->first.begin(); omit != hit->first.end(); ++omit) {
                         omit->mesh().current_barrier() = true;

--- a/OpenMEEG/src/interface.cpp
+++ b/OpenMEEG/src/interface.cpp
@@ -44,9 +44,9 @@ knowledge of the CeCILL-B license and that you accept its terms.
 namespace OpenMEEG {
 
     /// Computes the total solid angle of a surface for a point p and tells whether p is inside the mesh or not.
-    bool Interface::contains_point(const Vect3& p) const 
-    {
-        double solangle = compute_solid_angle(p);
+
+    bool Interface::contains_point(const Vect3& p) const {
+        double solangle = solid_angle(p);
 
         if ( almost_equal(solangle, 0.) ) {
             return false;
@@ -62,17 +62,15 @@ namespace OpenMEEG {
     }
 
     /// compute the solid-angle which should be +/-4 * Pi for a closed mesh if p is inside, 0 if p is outside
-    double Interface::compute_solid_angle(const Vect3& p) const 
-    {
+    double Interface::solid_angle(const Vect3& p) const {
         double solangle = 0.0;
         for ( Interface::const_iterator omit = begin(); omit != end(); ++omit) {
-                solangle += omit->orientation() * omit->mesh().compute_solid_angle(p);
+                solangle += omit->orientation() * omit->mesh().solid_angle(p);
         }
         return solangle;
     }
 
-    void Interface::set_to_outermost() 
-    {
+    void Interface::set_to_outermost() {
         for ( Interface::iterator omit = begin(); omit != end(); ++omit) {
             omit->mesh().outermost() = true;
         }
@@ -80,8 +78,8 @@ namespace OpenMEEG {
     }
 
     /// Check the global orientation: that the triangles are correctly oriented (outward-pointing normal)
-    bool Interface::check(bool checked)
-    {
+
+    bool Interface::check(const bool checked) {
         /// compute the bounding box:
         double xmin = std::numeric_limits<double>::max();
         double ymin = std::numeric_limits<double>::max();
@@ -108,7 +106,7 @@ namespace OpenMEEG {
         // TODO if solidangle returns 0, then the center of BB is not inside, and thus we should randomly choose another inside point until solid_anlge gives + or -4 PI ?
         // else it causes a strange phenomenon for symmetric model, the point chosen for interface Cortex {north and south}, is on the surface...
         // compute the solid-angle from an inside point:
-        double solangle = compute_solid_angle(bbcenter);
+        double solangle = solid_angle(bbcenter);
         bool closed;
 
         //if the bounding box center is not inside the interface,
@@ -125,7 +123,7 @@ namespace OpenMEEG {
                             (double)rand()/RAND_MAX*(ymax-ymin)+ymin,
                             (double)rand()/RAND_MAX*(zmax-zmin)+zmin);
                 //std::cout<<"\ttest random point("<<pt_rd<<")\n";
-                solangle=compute_solid_angle(pt_rd);
+                solangle = solid_angle(pt_rd);
             }
         }
 

--- a/OpenMEEG/src/operators.cpp
+++ b/OpenMEEG/src/operators.cpp
@@ -87,7 +87,7 @@ namespace OpenMEEG {
             #pragma omp critical
             {
                 for (unsigned i=0;i<3;++i)
-                    rhs(triangle(i).index()) += v(i)*coeff;
+                    rhs(triangle.vertex(i).index()) += v(i)*coeff;
             }
         }
         delete gauss;

--- a/apps/tools/make_nerve.cpp
+++ b/apps/tools/make_nerve.cpp
@@ -155,59 +155,48 @@ int cylindre (char namesurf[], char namepatches[], char namepatchcount[], double
     save=np;
     for (j=nl;j<(2*nl);j++) {
         for (i=0;i<nteta;i++) {
-            o=i*dteta + (j-nl)*dteta/2 + decal_teta;
-            P[np].x()=R*cos(o);
-            P[np].y()=R*sin(o);
-            P[np].z()=(j+1)*dl +z +3*ez+3*iz+iz2;
-            np ++;
+            o = i*dteta+(j-nl)*dteta/2+decal_teta;
+            P[np].x() = R*cos(o);
+            P[np].y() = R*sin(o);
+            P[np].z() = (j+1)*dl+z+3*ez+3*iz+iz2;
+            ++np;
         }
     }
 
 
     // definition of triangles before electrode
-    for (j=0;j<nl-1;j++) {
+    for (j=0;j<nl-1;j++)
         for (i=0;i<nteta;i++) {
-            T[nt]=Triangle(P[i+nteta*j], P[(i+1)%nteta +nteta*j], P[i+nteta*(j+1)]);
-            T[nt+1]=Triangle(P[i+nteta*j], P[i+nteta*(j+1)], P[(nteta+i-1)%nteta +nteta*(j+1)]);
-            nt += 2;
+            T[nt++] = Triangle(P[i+nteta*j], P[(i+1)%nteta +nteta*j], P[i+nteta*(j+1)]);
+            T[nt++] = Triangle(P[i+nteta*j], P[i+nteta*(j+1)], P[(nteta+i-1)%nteta +nteta*(j+1)]);
         }
-    }
 
     // definition of transition triangles
     for (i=0;i<nteta;i++) {
-        T[nt]=Triangle(P[i+nteta*(nl-1)], P[(2*i+1) + nteta*nl], P[2*i + nteta*nl]);
-        nt++;
-        T[nt]=Triangle(P[i+nteta*(nl-1)], P[(i+1)%nteta + nteta*(nl-1)], P[2*i+1 + nteta*nl]);
-        nt++;
-        T[nt]=Triangle(P[(i+1)%nteta+nteta*(nl-1)], P[(2*i+2)%(2*nteta) + nteta*nl], P[(2*i+1) + nteta*nl]);
-        nt++;
+        T[nt++] = Triangle(P[i+nteta*(nl-1)], P[(2*i+1) + nteta*nl], P[2*i + nteta*nl]);
+        T[nt++] = Triangle(P[i+nteta*(nl-1)], P[(i+1)%nteta + nteta*(nl-1)], P[2*i+1 + nteta*nl]);
+        T[nt++] = Triangle(P[(i+1)%nteta+nteta*(nl-1)], P[(2*i+2)%(2*nteta) + nteta*nl], P[(2*i+1) + nteta*nl]);
     }
 
     // definition of electrode triangles
-    for (j=0;j<(3*nez+3*niz+niz2);j++) {
+    for (j=0;j<(3*nez+3*niz+niz2);j++)
         for (i=0;i<2*nteta;i++) {
-            T[nt]=Triangle(P[i+2*nteta*j +nteta*nl], P[i+2*nteta*(j+1) +nteta*nl], P[(2*nteta+i-1)%(2*nteta) +2*nteta*(j+1) +nteta*nl]);
-            T[nt+1]=Triangle(P[i+2*nteta*j +nteta*nl], P[(i+1)%(2*nteta)+2*nteta*j +nteta*nl], P[i+2*nteta*(j+1) +nteta*nl]);
-            nt += 2;
+            T[nt++] = Triangle(P[i+2*nteta*j+nteta*nl],P[i+2*nteta*(j+1)+nteta*nl],P[(2*nteta+i-1)%(2*nteta)+2*nteta*(j+1)+nteta*nl]);
+            T[nt++] = Triangle(P[i+2*nteta*j+nteta*nl],P[(i+1)%(2*nteta)+2*nteta*j+nteta*nl],P[i+2*nteta*(j+1)+nteta*nl]);
         }
-    }
 
     // definition of transition triangles
     for (i=0;i<nteta;i++) {
-        T[nt]=Triangle(P[i +save], P[2*i  +save-2*nteta], P[(2*i+1) +save-2*nteta]);
-        nt++;
-        T[nt]=Triangle(P[i +save], P[(2*i+1) +save-2*nteta], P[(i+1)%nteta +save]);
-        nt++;
-        T[nt]=Triangle(P[(i+1)%nteta +save], P[(2*i+1) +save-2*nteta], P[(2*i+2)%(2*nteta) +save-2*nteta]);
-        nt++;
+        T[nt++] = Triangle(P[i+save],P[2*i+save-2*nteta],P[(2*i+1)+save-2*nteta]);
+        T[nt++] = Triangle(P[i+save],P[(2*i+1)+save-2*nteta],P[(i+1)%nteta+save]);
+        T[nt++] = Triangle(P[(i+1)%nteta+save],P[(2*i+1)+save-2*nteta],P[(2*i+2)%(2*nteta)+save-2*nteta]);
     }
 
     // definition of triangles after electrode
     for (j=0;j<nl-1;j++) {
         for (i=0;i<nteta;i++) {
-            T[nt]=Triangle(P[i+nteta*j +save], P[(i+1)%nteta +nteta*j +save], P[i+nteta*(j+1) +save]);
-            T[nt+1]=Triangle(P[i+nteta*j +save], P[i+nteta*(j+1) +save], P[(nteta+i-1)%nteta +nteta*(j+1) +save]);
-            nt += 2;
+            T[nt++] = Triangle(P[i+nteta*j+save],P[(i+1)%nteta+nteta*j+save],P[i+nteta*(j+1)+save]);
+            T[nt++] = Triangle(P[i+nteta*j+save],P[i+nteta*(j+1)+save],P[(nteta+i-1)%nteta+nteta*(j+1)+save]);
         }
     }
 
@@ -216,58 +205,48 @@ int cylindre (char namesurf[], char namepatches[], char namepatchcount[], double
     for (g=0;g<=1;g++) {
         num[c-1]=((g == 0)?(0):(save));
         for (j=0;j<c;j++) {
-            if (j == 0)
+            if (j==0)
                 N[0]=1;
             else
                 decoupe(dt/(R*sin(alpha*j)), 2*Pi, &N[j], &ang[j]);
-            if (j == c-1) break;
-            num[j]=np;
-            for (i=0;i<N[j];i++)
-            {
-                o=i*ang[j] + ((g == 0)?((-nl+1)*dteta/2):((nl-1)*dteta/2)) + decal_teta;
-                P[np].x()=R*sin(alpha*j)*cos(o);
-                P[np].y()=R*sin(alpha*j)*sin(o);
-                P[np].z()=g*L +z + R*cos(alpha*j) *(g*2-1) *0.3;
-                np ++;
+            if (j==c-1) break;
+            num[j] = np;
+            for (i=0;i<N[j];++i,++np) {
+                o = i*ang[j]+((g==0) ? 1-nl : nl-1)*dteta/2+decal_teta;
+                P[np].x() = R*sin(alpha*j)*cos(o);
+                P[np].y() = R*sin(alpha*j)*sin(o);
+                P[np].z() = g*L+z+R*cos(alpha*j)*(g*2-1)*0.3;
             }
         }
         for (j=2;j<c;j++) {
             k=0;
-            T[nt]=Triangle(P[num[j]], P[num[j]+1], P[num[j-1]]);
-            if (g == 0) {
-                T[nt].flip();
-            }
-            nt ++;
-            for (i=1;i<N[j];i++)
-            {
-                if (ang[j-1]*(k+0.5) < ang[j]*(i+0.5))
-                {
-                    T[nt]=Triangle(P[num[j]+i], P[num[j-1]+(k+1)%N[j-1]], P[num[j-1]+k]);
-                    if (g == 0) { 
-                        T[nt].flip(); 
-                    }
-                    k=(k+1)%N[j-1];
-                    nt ++;
+            T[nt] = Triangle(P[num[j]],P[num[j]+1],P[num[j-1]]);
+            if (g==0)
+                T[nt].change_orientation();
+            ++nt;
+            for (i=1;i<N[j];i++) {
+                if (ang[j-1]*(k+0.5)<ang[j]*(i+0.5)) {
+                    T[nt] = Triangle(P[num[j]+i], P[num[j-1]+(k+1)%N[j-1]], P[num[j-1]+k]);
+                    if (g==0)
+                        T[nt].change_orientation(); 
+                    k = (k+1)%N[j-1];
+                    ++nt;
                 }
-                T[nt]=Triangle(P[num[j]+i%N[j]], P[num[j]+(i+1)%N[j]], P[num[j-1]+k]);
-                if (g == 0) { 
-                    T[nt].flip();
-                }
-                nt ++;
+                T[nt] = Triangle(P[num[j]+i%N[j]], P[num[j]+(i+1)%N[j]], P[num[j-1]+k]);
+                if (g==0)
+                    T[nt].change_orientation();
+                ++nt;
             }
         }
-        for (i=0;i<N[1];i++) {
-            T[nt]=Triangle(P[num[1]+i], P[num[1]+(i+1)%N[1]], P[num[0]]);
-            if (g == 0) {
-                T[nt].flip();
-            }
-            nt ++;
+        for (i=0;i<N[1];++i,++nt) {
+            T[nt] = Triangle(P[num[1]+i],P[num[1]+(i+1)%N[1]],P[num[0]]);
+            if (g==0)
+                T[nt].change_orientation();
         }
     }
     Mesh surf(P);
-    for (i=0;i<nt;i++) {
+    for (i=0;i<nt;++i)
         surf.push_back(T[i]);
-    }
     surf.save(namesurf);
 
     //the electrode
@@ -331,7 +310,7 @@ int cylindre (char namesurf[], char namepatches[], char namepatchcount[], double
         }
         for (j=0;j<12;j++){
             for (i=0; i<maxelectrodetriangles;++i){ // compute the barycenters of the triangles corresponding to each electrode
-                electrodecenter = (T[electrodetriangles[j][i]].s1() + T[electrodetriangles[j][i]].s2() + T[electrodetriangles[j][i]].s3()) / 3.;
+                electrodecenter = (T[electrodetriangles[j][i]].vertex(0)+T[electrodetriangles[j][i]].vertex(1)+T[electrodetriangles[j][i]].vertex(2))/3;
                 ofs1 << electrodecenter.x() << ' ' << electrodecenter.y() << ' ' << electrodecenter.z() << std::endl;
             }
             ofs2 << i << std::endl; // the number of patches used to represent electrode j

--- a/apps/tools/mesh_convert.cpp
+++ b/apps/tools/mesh_convert.cpp
@@ -111,8 +111,8 @@ int main( int argc, char **argv) {
     }
 
     if ( invert ) {
-        std::cout << "Running face flipping" << std::endl;
-        m.flip_triangles();
+        std::cout << "Change mesh orientation" << std::endl;
+        m.change_orientation();
     }
 
     m.correct_local_orientation();

--- a/apps/tools/project_sensors.cpp
+++ b/apps/tools/project_sensors.cpp
@@ -74,19 +74,17 @@ int main( int argc, char** argv)
 
     size_t nb_positions = sensors.getNumberOfPositions();
 
-    for( size_t i = 0; i < nb_positions; ++i )
-    {
-        Vector position = sensors.getPosition(i);
-        Vect3 current_position, alphas;
-        for ( unsigned k = 0; k < 3; ++k) {
+    for (size_t i=0;i<nb_positions;++i) {
+        const Vector position = sensors.getPosition(i);
+        Vect3 current_position;
+        for (unsigned k=0;k<3;++k)
             current_position(k) = position(k);
-        }
+        Vect3 alphas;
         Triangle triangle; // closest triangle
-        dist_point_interface(current_position, interface, alphas, triangle);
-        current_position = alphas(0)*triangle(0)+alphas(1)*triangle(1)+alphas(2)*triangle(2);
-        for ( unsigned k = 0; k < 3; ++k) {
+        dist_point_interface(current_position,interface,alphas,triangle);
+        current_position = alphas(0)*triangle.vertex(0)+alphas(1)*triangle.vertex(1)+alphas(2)*triangle.vertex(2);
+        for (unsigned k=0;k<3;++k)
             output(i,k) = current_position(k);
-        }
     }
 
     sensors.getPositions() = output;

--- a/tests/test_validationEIT.cpp
+++ b/tests/test_validationEIT.cpp
@@ -127,14 +127,12 @@ int main(const int argc, const char* argv[]) {
     SparseMatrix matH2E(electrodes.getNumberOfSensors(), newsize); // Matrices Head2Electrodes
 
     // Find the triangle closest to the electrodes
-    for ( unsigned ielec = 0; ielec < nelec; ++ielec) {
-        for ( unsigned k = 0; k < 3; ++k) {
+    for (unsigned ielec=0;ielec<nelec;++ielec) {
+        for (unsigned k=0;k<3;++k)
             current_position(k) = electrodes_positions(ielec, k);
-        }
         dist_point_interface(current_position, geo.outermost_interface(), current_alphas, current_nearest_triangle);
-        matH2E(ielec, current_nearest_triangle.s1().index()) = current_alphas(0);
-        matH2E(ielec, current_nearest_triangle.s2().index()) = current_alphas(1);
-        matH2E(ielec, current_nearest_triangle.s3().index()) = current_alphas(2);
+        for (unsigned k=0;k<3;++k)
+            matH2E(ielec,current_nearest_triangle.vertex(k).index()) = current_alphas(k);
     }
 
     // Potential at the electrodes positions


### PR DESCRIPTION
Some ugly things I noticed a while ago but never corrected.
Triangle edges were iterated over by going through vertices (i,i+1) for i from 0 to 2.
For i=2, this means that we were accessing to the fourth vertex of a triangle. s this is wrong this was handled by having a modulo 3  in the vertex accessor.
This PR corrects the problem at its source by never accessing the "fourth vertex".