### PR TITLE
Attempt to fix conda failure in appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -58,7 +58,7 @@ install:
   ############################################################################
   - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-  - CALL "%PYTHON_ROOT%\\Scripts\\activate.bat"
+  - CALL "%PYTHON%\\Scripts\\activate.bat"
 
   ############################################################################
   # Install CMake

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,9 +57,8 @@ install:
   # Install Conda
   ############################################################################
   - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
-  - $env:CONDA_VERSION="4.3.34"
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - CALL "%PYTHON_ROOT%\\Scripts\\activate.bat"
 
   ############################################################################
   # Install CMake

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,6 +57,7 @@ install:
   # Install Conda
   ############################################################################
   - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+  - $env:CONDA_VERSION="4.3.34"
   - "powershell ci-helpers/appveyor/install-miniconda.ps1"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,6 @@ before_install:
       curl -fsSkL https://raw.githubusercontent.com/openmeeg/ci-utils/master/travis/install_mkl.sh > install_mkl.sh && source ./install_mkl.sh
     fi
 
-
   ############################################################################
   # Install Matio (using conda for shipping in Linux)
   ############################################################################


### PR DESCRIPTION
On internet two solution are proposed:
- downgrade to conda 4.3.34
- avoid path manipulation and instead call a script (see https://github.com/conda/conda/issues/8836)

Attempting the last one.