### PR TITLE
reveal bug with make_geometry

### DIFF
--- a/wrapping/src/test_make_geometry.py
+++ b/wrapping/src/test_make_geometry.py
@@ -50,4 +50,7 @@ g1 = om.make_geometry(interfaces, domains)
 g2 = om.Geometry(
     op.join(dirpath, subject + ".geom"), op.join(dirpath, subject + ".cond"))
 
+assert g1.is_nested()
+assert g2.is_nested()
+
 assert g1.__class__ == g2.__class__


### PR DESCRIPTION
@papadop here is just a tiny diff to show a bug I observed while trying to obtain forwards using MNE

you'll see that the make_geometry function does not produce the same type of Geometry as when going file based. It does not say it's nested.

can you have a look?