### PR TITLE
Adapt MatlabIO.H to handle both older and newer version of matio 

### DIFF
--- a/OpenMEEGMaths/include/MatlabIO.H
+++ b/OpenMEEGMaths/include/MatlabIO.H
@@ -352,12 +352,19 @@ namespace OpenMEEG {
                     tank_inverted[std::pair<size_t,size_t>(j,i)] = val;
                 }
 
-                const int sz = linop.size();
-                const int num = linop.ncol()+1;
 
-                double* t  = new double[sz];
-                int*    ir = new int[sz];
-                int*    jc = new int[num];
+                #if MATIO_VERSION>=1518
+                    typedef mat_uint32_t matio_int_type;
+                #else
+                    typedef int matio_int_type;
+                #endif
+
+                const matio_int_type sz  = linop.size();
+                const matio_int_type num = linop.ncol()+1;
+                matio_int_type*      ir  = new matio_int_type[sz];
+                matio_int_type*      jc  = new matio_int_type[num];
+
+                double* t = new double[sz];
 
                 size_t cnt = 0;
                 size_t current_col = (size_t)-1;


### PR DESCRIPTION
closes #421

This is an adaptation to a new interface that appeared with matio-1.5.18.
It is just a small type change.
Note that the testers will only (for now) check that the code compiles with versions older than 1.5.18 (as this is what is inslled on the testers), but I checked on my side that the change (which is quite obvious) works with 1.5.18.