### PR TITLE
Factorize head matrix

### DIFF
--- a/OpenMEEGMaths/include/Exceptions.H
+++ b/OpenMEEGMaths/include/Exceptions.H
@@ -7,6 +7,8 @@
 #include <iostream>
 #include <exception>
 
+#include <range.h>
+
 #include "OpenMEEGMaths_Export.h"
 
 namespace OpenMEEG {
@@ -14,9 +16,9 @@ namespace OpenMEEG {
 
         typedef enum { UNEXPECTED = 128, IO_EXCPT,
                        BAD_FILE, BAD_FILE_OPEN, BAD_CONTENT, NO_SUFFIX, BAD_HDR, BAD_DATA, BAD_VECT, UNKN_DIM, BAD_SYMM_MAT,
-                       BAD_STORAGE_TYPE, NO_IO, MATIO_ERROR, UNKN_FILE_FMT, UNKN_FILE_SUFFIX, NO_FILE_FMT, UNKN_NAMED_FILE_FMT,
-                       IMPOSSIBLE_IDENTIFICATION } ExceptionCode;
-
+                       BAD_STORAGE_TYPE, NO_IO, OVERLAPPING_RANGES, NON_EXISTING_BLOCK, MATIO_ERROR, UNKN_FILE_FMT,
+                       UNKN_FILE_SUFFIX, NO_FILE_FMT, UNKN_NAMED_FILE_FMT, IMPOSSIBLE_IDENTIFICATION
+                     } ExceptionCode;
 
         class Exception: public std::exception {
         public:
@@ -205,6 +207,36 @@ namespace OpenMEEG {
 
             static std::string message(const std::string& file,const Mode& mode) {
                 return std::string("Unable to find ")+((mode==READ) ? "reader" : "writer")+" for file "+file+".";
+            }
+        };
+
+        struct OPENMEEGMATHS_EXPORT OverlappingRanges: public Exception {
+
+            OverlappingRanges(const Range& r1,const Range& r2): Exception(message(r1,r2)) { }
+
+            ExceptionCode code() const throw() { return OVERLAPPING_RANGES; }
+
+        private:
+
+            static std::string message(const Range& r1,const Range& r2) {
+                std::ostringstream ost;
+                ost << "Ranges " << r1 << " and " << r2 << " are overlapping blocks in a block matrix.";
+                return ost.str();
+            }
+        };
+
+        struct OPENMEEGMATHS_EXPORT NonExistingBlock: public Exception {
+
+            NonExistingBlock(const unsigned ind): Exception(message(ind)) { }
+
+            ExceptionCode code() const throw() { return NON_EXISTING_BLOCK; }
+
+        private:
+
+            static std::string message(const unsigned ind) {
+                std::ostringstream ost;
+                ost << "Attempt to access a non-existing block at index " << ind << '.';
+                return ost.str();
             }
         };
 

--- a/OpenMEEGMaths/include/block_matrix.h
+++ b/OpenMEEGMaths/include/block_matrix.h
@@ -1,0 +1,141 @@
+/*
+Project Name : OpenMEEG
+
+© INRIA and ENPC (contributors: Geoffray ADDE, Maureen CLERC, Alexandre
+GRAMFORT, Renaud KERIVEN, Jan KYBIC, Perrine LANDREAU, Théodore PAPADOPOULO,
+Emmanuel OLIVI
+Maureen.Clerc.AT.inria.fr, keriven.AT.certis.enpc.fr,
+kybic.AT.fel.cvut.cz, papadop.AT.inria.fr)
+
+The OpenMEEG software is a C++ package for solving the forward/inverse
+problems of electroencephalography and magnetoencephalography.
+
+This software is governed by the CeCILL-B license under French law and
+abiding by the rules of distribution of free software.  You can  use,
+modify and/ or redistribute the software under the terms of the CeCILL-B
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info".
+
+As a counterpart to the access to the source code and  rights to copy,
+modify and redistribute granted by the license, users are provided only
+with a limited warranty  and the software's authors,  the holders of the
+economic rights,  and the successive licensors  have only  limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading,  using,  modifying and/or developing or reproducing the
+software by the user in light of its specific status of free software,
+that may mean  that it is complicated to manipulate,  and  that  also
+therefore means  that it is reserved for developers  and  experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and,  more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL-B license and that you accept its terms.
+*/
+
+#pragma once
+
+#include <OpenMEEGMathsConfig.h>
+#include <iostream>
+#include <vector>
+#include <map>
+
+#include <linop.h>
+#include <range.h>
+#include <Exceptions.H>
+
+namespace OpenMEEG::maths {
+
+    /// \brief  Block matrix class
+    /// Block matrix class
+
+    class OPENMEEGMATHS_EXPORT BlockMatrix: public LinOp {
+
+        typedef std::vector<Range>           Ranges;
+        typedef std::pair<unsigned,unsigned> Index;
+        typedef std::map<Index,Matrix>       Blocks;
+
+    public:
+
+        BlockMatrix(): LinOp(0,0,BLOCK,2) { }
+        BlockMatrix(const size_t M,const size_t N): LinOp(M,N,BLOCK,2) { }
+
+              Matrix& block(const unsigned i,const unsigned j)       { return blocks[{i,j}];    }
+        const Matrix& block(const unsigned i,const unsigned j) const { return blocks.at({i,j}); }
+
+        void add_block(const Range& ir,const Range& jr) {
+            Index inds = find_block_indices(ir,jr);
+            if (inds.first==-1) {
+                iranges.push_back(ir);
+                inds.first = iranges.size()-1;
+            }
+            if (inds.second==-1) {
+                jranges.push_back(jr);
+                inds.second = jranges.size()-1;
+            }
+            blocks[inds] = Matrix(ir.length(),jr.length());
+        }
+
+        void set_blocks(const Ranges& rs) {
+            iranges = rs;
+            jranges = rs;
+            for (const auto& ir : iranges)
+                for (const auto& jr : jranges)
+                    add_block(ir,jr);
+        }
+
+        double& operator()(const size_t i,const size_t j) {
+            const Index& ind = find_block_indices(i,j);
+            const size_t inblockindex_i = i-iranges[ind.first].start();
+            const size_t inblockindex_j = j-jranges[ind.second].start();
+            return blocks[ind](inblockindex_i,inblockindex_j);
+        }
+
+        double  operator()(const size_t i,const size_t j) const {
+            const Index& ind = find_block_indices(i,j);
+            const size_t inblockindex_i = i-iranges[ind.first].start();
+            const size_t inblockindex_j = j-jranges[ind.second].start();
+            return blocks.at(ind)(inblockindex_i,inblockindex_j);
+        }
+
+    private:
+
+        Index find_block_indices(const Range& ir,const Range& jr) const {
+            const unsigned iind = find_overlapping_range(ir,iranges);
+            if (iind!=-1 && ir!=iranges[iind])
+                throw OverlappingRanges(ir,iranges[iind]);
+            const unsigned jind = find_overlapping_range(jr,jranges);
+            if (jind!=-1 && jr!=iranges[jind])
+                throw OverlappingRanges(jr,iranges[jind]);
+            return {iind,jind};
+        }
+
+        static unsigned find_overlapping_range(const Range& r,const Ranges& ranges) {
+            for (unsigned i=0;i<ranges.size();++i)
+                if (ranges[i].intersect(r))
+                    return i;
+            return -1;
+        }
+
+        static unsigned find_block_index(const size_t ind,const Ranges& ranges) {
+            for (unsigned i=0;i<ranges.size();++i)
+                if (ranges[i].contains(ind))
+                    return i;
+            throw NonExistingBlock(ind);
+        }
+        
+        Index find_block_indices(const size_t i,const unsigned j) const {
+            const unsigned iind = find_block_index(i,iranges);
+            const unsigned jind = find_block_index(j,jranges);
+            return { iind, jind };
+        }
+
+        Ranges iranges;
+        Ranges jranges;
+        Blocks blocks;
+    };
+}

--- a/OpenMEEGMaths/include/block_matrix.h
+++ b/OpenMEEGMaths/include/block_matrix.h
@@ -43,9 +43,11 @@ knowledge of the CeCILL-B license and that you accept its terms.
 #include <iostream>
 #include <vector>
 #include <map>
+#include <algorithm>
 
 #include <linop.h>
 #include <range.h>
+#include <matrix.h>
 #include <Exceptions.H>
 
 namespace OpenMEEG::maths {

--- a/OpenMEEGMaths/include/linop.h
+++ b/OpenMEEGMaths/include/linop.h
@@ -61,11 +61,11 @@ namespace OpenMEEG {
         struct OPENMEEGMATHS_EXPORT MathsIO;
     }
 
-    // to properly convert a size_t int to an int
-    OPENMEEGMATHS_EXPORT inline BLAS_INT sizet_to_int(const size_t& num)
-    {
+    // Properly convert a size_t int to an int
+
+    OPENMEEGMATHS_EXPORT inline BLAS_INT sizet_to_int(const size_t& num) {
         BLAS_INT num_out = static_cast<BLAS_INT>(num);
-        om_assert(num_out >= 0);
+        om_assert(num_out>=0);
         return num_out;
     }
 
@@ -74,8 +74,8 @@ namespace OpenMEEG {
 
         typedef maths::MathsIO* IO;
 
-        typedef enum { FULL, SYMMETRIC, SPARSE } StorageType;
-        typedef unsigned                         Dimension;
+        typedef enum { FULL, SYMMETRIC, BLOCK, SPARSE } StorageType;
+        typedef unsigned                                Dimension;
 
         LinOpInfo() { }
         LinOpInfo(const size_t m,const size_t n,const StorageType st,const Dimension d):
@@ -99,11 +99,11 @@ namespace OpenMEEG {
 
     protected:
 
-        size_t            num_lines;
-        size_t            num_cols;
-        StorageType       storage;
-        Dimension         dim;
-        IO                DefaultIO;
+        size_t      num_lines;
+        size_t      num_cols;
+        StorageType storage;
+        Dimension   dim;
+        IO          DefaultIO;
     };
 
     class OPENMEEGMATHS_EXPORT LinOp: public LinOpInfo {

--- a/OpenMEEGMaths/include/range.h
+++ b/OpenMEEGMaths/include/range.h
@@ -1,0 +1,74 @@
+/*
+Project Name : OpenMEEG
+
+© INRIA and ENPC (contributors: Geoffray ADDE, Maureen CLERC, Alexandre
+GRAMFORT, Renaud KERIVEN, Jan KYBIC, Perrine LANDREAU, Théodore PAPADOPOULO,
+Emmanuel OLIVI
+Maureen.Clerc.AT.inria.fr, keriven.AT.certis.enpc.fr,
+kybic.AT.fel.cvut.cz, papadop.AT.inria.fr)
+
+The OpenMEEG software is a C++ package for solving the forward/inverse
+problems of electroencephalography and magnetoencephalography.
+
+This software is governed by the CeCILL-B license under French law and
+abiding by the rules of distribution of free software.  You can  use,
+modify and/ or redistribute the software under the terms of the CeCILL-B
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info".
+
+As a counterpart to the access to the source code and  rights to copy,
+modify and redistribute granted by the license, users are provided only
+with a limited warranty  and the software's authors,  the holders of the
+economic rights,  and the successive licensors  have only  limited
+liability.
+
+In this respect, the user's attention is drawn to the risks associated
+with loading,  using,  modifying and/or developing or reproducing the
+software by the user in light of its specific status of free software,
+that may mean  that it is complicated to manipulate,  and  that  also
+therefore means  that it is reserved for developers  and  experienced
+professionals having in-depth computer knowledge. Users are therefore
+encouraged to load and test the software's suitability as regards their
+requirements in conditions enabling the security of their systems and/or
+data to be ensured and,  more generally, to use and operate it in the
+same conditions as regards security.
+
+The fact that you are presently reading this means that you have had
+knowledge of the CeCILL-B license and that you accept its terms.
+*/
+
+#pragma once
+
+#include <iostream>
+
+#include "OpenMEEGMathsConfig.h"
+
+namespace OpenMEEG::maths {
+
+    class OPENMEEGMATHS_EXPORT Range {
+    public:
+
+        Range(): start_index(0),end_index(0) { }
+        Range(const size_t s,const size_t e): start_index(s),end_index(e) { }
+
+        size_t start() const { return start_index; }
+        size_t end()   const { return end_index;   }
+
+        size_t length() const { return end()-start()+1; }
+
+        bool contains(const size_t ind) const { return ind>=start() && ind<=end();               }
+        bool intersect(const Range& r)  const { return contains(r.start()) || contains(r.end()); }
+
+        bool operator==(const Range& r) const { return start()==r.start() && end()==r.end();      }
+        bool operator!=(const Range& r) const { return start()!=r.start() || end()!=r.end();      }
+
+    private:
+
+        size_t start_index;
+        size_t end_index;
+    };
+
+    inline std::ostream& operator<<(std::ostream& os,const Range& r) {
+        return os << '(' << r.start() << ',' << r.end() << ')';
+    }
+}

--- a/apps/ComparisonTest_caller.cmake
+++ b/apps/ComparisonTest_caller.cmake
@@ -220,7 +220,7 @@ set(EPSILONMN2 0.10)
 foreach(DIP 1 2 3 4 5 6)
     foreach(HEADNUM MN1 MN2)
         foreach(COMP mag rdm)
-        set(HEAD "Head${HEADNUM}")
+            set(HEAD "Head${HEADNUM}")
             foreach(ADJOINT "" adjoint adjoint2)
                 set(BASE_FILE_NAME "${HEAD}-dip.est_eeg${ADJOINT}")
                 OPENMEEG_COMPARISON_TEST("EEG${ADJOINT}EST-dip-${HEAD}-dip${DIP}-${COMP}" ${BASE_FILE_NAME} analytic/eeg_head${HEADNUM}_analytic.txt 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,14 +13,9 @@ target_link_libraries(test_validationEIT OpenMEEG::OpenMEEG)
 add_executable(test_compare_matrix test_compare_matrix.cpp)
 target_link_libraries(test_compare_matrix OpenMEEG::OpenMEEG OpenMEEG::OpenMEEGMaths)
 
-# tests
 if (BUILD_TESTING)
     OPENMEEG_TEST(check_test_load_geo
         test_load_geo ${OpenMEEG_SOURCE_DIR}/data/Head1/Head1.geom ${OpenMEEG_SOURCE_DIR}/data/Head1/Head1.cond)
     OPENMEEG_TEST(check_test_mesh_ios
         test_mesh_ios ${OpenMEEG_SOURCE_DIR}/data/Head1/Head1.tri)
 endif()
-
-
-######
-

--- a/wrapping/src/openmeeg.i
+++ b/wrapping/src/openmeeg.i
@@ -29,6 +29,7 @@
     #include <matrix.h>
     #include <symmatrix.h>
     #include <sparse_matrix.h>
+    #include <block_matrix.h>
     #include <fast_sparse_matrix.h>
     #include <sensors.h>
     #include <geometry.h>


### PR DESCRIPTION
This PR factorizes the redundant code in HeadMat::HeadMat and HeadMatrix.
Note that this potentially also corrects some bug as the two versions were slightly different in the test for operatorD*.
 HeadMat::HeadMat was doing:  if ((mesh1!=mesh2) && (!mesh2.current_barrier()))
while
HeadMatrix was doing: if ((mesh1!=mesh2) && mesh2.current_barrier())

This is an untested cornercase (HeadMatrix is used only for CorticalMat and CorticalMat2), so I adopted the HeadMat::HeadMat variant, which I think is better tested. All tests are passing correctly.