### PR TITLE
MAINT: Two more warnings

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,11 +67,11 @@ jobs:
         else
           BUILD_DOCS=OFF
         fi
-        # Use -Werror on Windows, eventually should use everywhere
-        if [[ ${{matrix.os}} == 'windows*' ]]; then
-          ENABLE_WERROR=ON
-        else
+        # Use -Werror on Windows and macOS, eventually should use on Linux
+        if [[ ${{matrix.os}} != 'ubuntu*' ]]; then
           ENABLE_WERROR=OFF
+        else
+          ENABLE_WERROR=ON
         fi
         echo "ENABLE_WERROR=$ENABLE_WERROR" >> $GITHUB_ENV
         echo "DOC_OPT=-DBUILD_DOCUMENTATION=$BUILD_DOCS" >> $GITHUB_ENV

--- a/OpenMEEG/include/GeometryIO.h
+++ b/OpenMEEG/include/GeometryIO.h
@@ -81,6 +81,8 @@ namespace OpenMEEG {
             write();
         }
 
+        virtual ~GeometryIO() = default;
+
     protected:
 
         virtual void   load_meshes(Geometry& geometry) = 0;

--- a/wrapping/src/openmeeg.i
+++ b/wrapping/src/openmeeg.i
@@ -305,7 +305,7 @@ namespace OpenMEEG {
             !PyArray_EquivTypenums(type_num, NPY_INT64) &&
             !PyArray_EquivTypenums(type_num, NPY_UINT64)) {
             std::vector<char> buf(1000); // note +1 for null terminator
-            std::snprintf(&buf[0], buf.size(), "Wrong dtype for triangles array (only 32 or 64 int or uint supported), got type '%c%d'", descr->kind, descr->elsize, type_num);
+            std::snprintf(&buf[0], buf.size(), "Wrong dtype for triangles array (only 32 or 64 int or uint supported), got type '%c%d'", descr->kind, descr->elsize);
             PyErr_SetString(PyExc_TypeError,&buf[0]);
             return;
         }


### PR DESCRIPTION
Takes care of:
```
[ 86%] Building CXX object wrapping/src/CMakeFiles/openmeeg.dir/CMakeFiles/openmeeg.dir/openmeegPYTHON_wrap.cxx.o
/Users/larsoner/python/openmeeg/build/wrapping/src/CMakeFiles/openmeeg.dir/openmeegPYTHON_wrap.cxx:6316:166: warning: data argument not used by format string [-Wformat-extra-args]
            std::snprintf(&buf[0], buf.size(), "Wrong dtype for triangles array (only 32 or 64 int or uint supported), got type '%c%d'", descr->kind, descr->elsize, type_num);
                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                              ^
/Users/larsoner/python/openmeeg/build/wrapping/src/CMakeFiles/openmeeg.dir/openmeegPYTHON_wrap.cxx:45802:7: warning: delete called on 'OpenMEEG::GeometryIO' that is abstract but has non-virtual destructor [-Wdelete-abstract-non-virtual-dtor]
      delete arg1;
      ^
```
Also renames the GitHub action to make more sense, and turns on warnings-as-errors on macOS. Just Linux after that (which I'll try to take care of when on my Linux machine sometime).