### PR TITLE
Rename conductivity_difference into conductivity_jump which is more m…

### DIFF
--- a/OpenMEEG/include/geometry.h
+++ b/OpenMEEG/include/geometry.h
@@ -198,14 +198,28 @@ namespace OpenMEEG {
         double sigma_inv(const Mesh& m1,const Mesh& m2) const { return eval_on_common_domains<INVERSE>(m1,m2);   } // return the (sum) inverse of conductivity(ies) of the shared domain(s).
         double indicator(const Mesh& m1,const Mesh& m2) const { return eval_on_common_domains<INDICATOR>(m1,m2); } // return the (sum) indicator function of the shared domain(s).
 
-        double conductivity_difference(const Mesh& m) const; // return the difference of conductivities of the 2 domains.
+        /// \brief Return the conductivity jump across a mesh (i.e. between the 2 domains it separates).
+
+        double conductivity_jump(const Mesh& m) const {
+            const DomainsReference& doms = domains(m);
+            double res = 0.0;
+            for (const auto& domainptr : doms)
+                res += domainptr->conductivity()*domainptr->mesh_orientation(m);
+            return res;
+        }
 
         /// \brief Give the relative orientation of two meshes:
         /// \return  0, if they don't have any domains in common
         ///          1, if they are both oriented toward the same domain
         ///         -1, if they are not
 
-        int oriented(const Mesh&,const Mesh&) const;
+        int oriented(const Mesh& m1,const Mesh& m2) const {
+            if (&m1==&m2) // Fast path for identical meshes.
+                return 1;
+            const DomainsReference& doms = common_domains(m1,m2); // 2 meshes have either 0, 1 or 2 domains in common
+            return (doms.size()==0) ? 0 : ((doms[0]->mesh_orientation(m1)==doms[0]->mesh_orientation(m2)) ? 1 : -1);
+        }
+
 
         //  Calling this method read induces failures due do wrong conversions when read is passed with one or two arguments...
 

--- a/OpenMEEG/include/geometry.h
+++ b/OpenMEEG/include/geometry.h
@@ -213,7 +213,7 @@ namespace OpenMEEG {
         ///          1, if they are both oriented toward the same domain
         ///         -1, if they are not
 
-        int oriented(const Mesh& m1,const Mesh& m2) const {
+        int relative_orientation(const Mesh& m1,const Mesh& m2) const {
             if (&m1==&m2) // Fast path for identical meshes.
                 return 1;
             const DomainsReference& doms = common_domains(m1,m2); // 2 meshes have either 0, 1 or 2 domains in common

--- a/OpenMEEG/src/assembleFerguson.cpp
+++ b/OpenMEEG/src/assembleFerguson.cpp
@@ -54,7 +54,7 @@ namespace OpenMEEG {
         const unsigned n = pts.nlin();
         ProgressBar pb(geom.meshes().size()*n);
         for (const auto& mesh : geom.meshes()) {
-            const double coeff = MagFactor*geom.conductivity_difference(mesh);
+            const double coeff = MagFactor*geom.conductivity_jump(mesh);
             for (unsigned i=0,index=0; i<n; ++i,index+=3,++pb) {
                 const Vect3 p(pts(i,0),pts(i,1),pts(i,2));
                 operatorFerguson(p,mesh,mat,index,coeff);

--- a/OpenMEEG/src/assembleSourceMat.cpp
+++ b/OpenMEEG/src/assembleSourceMat.cpp
@@ -152,11 +152,11 @@ namespace OpenMEEG {
 
             if (mesh1.current_barrier()) {
                 const NonDiagonalBlock operators(mesh1,mesh2,integrator);
-                const int orientation = geo.oriented(mesh1,mesh2);
+                const int orientation = geo.relative_orientation(mesh1,mesh2);
                 operators.D(K*orientation,transmat); // D23 or D33 of the formula.
-                if (&mesh1==&mesh2) { // I_33 of the formula.
+                if (&mesh1==&mesh2) { // I_33 of the formula, orientation is necessarily 1.
                     DiagonalBlock block(mesh1,integrator);
-                    block.addId(-0.5*orientation,transmat);
+                    block.addId(-0.5,transmat);
                 } else { // S_2 of the formula.
                     operators.S(-K*orientation*geo.sigma_inv(mesh1,mesh2),transmat);
                 }

--- a/OpenMEEG/src/geometry.cpp
+++ b/OpenMEEG/src/geometry.cpp
@@ -315,23 +315,6 @@ namespace OpenMEEG {
         num_params = index;
     }
 
-    /// \return the difference of conductivities of the 2 domains.
-
-    double Geometry::conductivity_difference(const Mesh& m) const {
-        const DomainsReference& doms = domains(m);
-        double res = 0.0;
-        for (const auto& domainptr : doms)
-            res += domainptr->conductivity()*domainptr->mesh_orientation(m);
-        return res;
-    }
-
-    /// \return 0. for non communicating meshes, 1. for same oriented meshes, -1. for different orientation
-
-    int Geometry::oriented(const Mesh& m1,const Mesh& m2) const {
-        const DomainsReference& doms = common_domains(m1,m2); // 2 meshes have either 0, 1 or 2 domains in common
-        return (doms.size()==0) ? 0 : ((doms[0]->mesh_orientation(m1)==doms[0]->mesh_orientation(m2)) ? 1 : -1);
-    }
-
     bool Geometry::selfCheck() const {
 
         bool OK = true;

--- a/OpenMEEG/src/geometry.cpp
+++ b/OpenMEEG/src/geometry.cpp
@@ -426,7 +426,7 @@ namespace OpenMEEG {
         for (const auto& mesh1 : meshes())
             if (!mesh1.isolated())
                 for (const auto& mesh2 : meshes()) {
-                    const int orientation = oriented(mesh1,mesh2);
+                    const int orientation = relative_orientation(mesh1,mesh2);
                     if ((!mesh2.isolated()) && (sigma(mesh1,mesh2)!=0.0) && orientation!=0) {
                         // Communicating meshes are used for the definition of a common domain
                         meshpairs.push_back(MeshPair(mesh1,mesh2,orientation));


### PR DESCRIPTION
This started by the simple renaming of the two methods:
- conductivity_difference -> conductivity_jump
- oriented -> relative_orientation
which is more meaningful and closer to mathematics.

Then I moved two methods into the .h for better readability (and inlining).
Finally, I added a fast path in the case of two identical meshes in which case the relative_orientation is necessarily equal to 1.