### PR TITLE
ENH: Add clang-format

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,1 @@
+./OpenMEEGMaths/include/BlasLapackImplementations/complex_msvc_vendor.h

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,22 @@
+name: clang-format
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    # https://github.com/marketplace/actions/clang-format-lint
+    - uses: DoozyX/clang-format-lint-action@v0.14
+      with:
+        source: '.'
+        clangFormatVersion: 13
+        inplace: ${{ contains(github.event.head_commit.message, '[actions format]') }}
+    - uses: EndBug/add-and-commit@v4
+      with:
+        author_name: Clang Robot
+        author_email: robot@example.com
+        message: 'Committing clang-format changes'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ contains(github.event.head_commit.message, '[actions format]') }}

--- a/OpenMEEG/include/Triangle_triangle_intersection.h
+++ b/OpenMEEG/include/Triangle_triangle_intersection.h
@@ -47,6 +47,7 @@
 /*****************************************************************************/
 
 #include <cmath>
+#include <triangle.h>
 
 namespace OpenMEEG {
 

--- a/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/include/assemble.h
@@ -56,9 +56,9 @@ knowledge of the CeCILL-B license and that you accept its terms.
 namespace OpenMEEG {
 
     // For ADAPT_LHS change the 0 in Integrator below into 10
-    // It would be nice to define some constant integrators for the default values but swig does not like them. 
+    // It would be nice to define some constant integrators for the default values but swig does not like them.
 
-    OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3,0,0.005));
+    OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3, 0, 0.005));
     OPENMEEG_EXPORT Matrix SurfSourceMat(const Geometry& geo,Mesh& sources,const Integrator& integrator=Integrator(3,0,0.005));
 
     OPENMEEG_EXPORT Matrix

--- a/wrapping/python/openmeeg/tests/test_doc.py
+++ b/wrapping/python/openmeeg/tests/test_doc.py
@@ -7,5 +7,5 @@ def test_doc():
     assert doc is not None
 
     headmat_expected_docstring = \
-        ("HeadMat(Geometry geo, Integrator const & integrator=Integrator(3,0,0.005)) -> SymMatrix")
+        ("HeadMat(Geometry geo, Integrator const & integrator=Integrator(3, 0, 0.005)) -> SymMatrix")
     assert doc == headmat_expected_docstring, f'got: {repr(doc)} != expected: {repr(headmat_expected_docstring)}'


### PR DESCRIPTION
Let's see if this works.

I don't think in the end we'd want the auto-commit on PR, just on push. That way people can work on PRs in any way they want, then once the commit is merged, `clang-format` fixes the code and pushes a commit.

Closes #444

- [x] Push first commit that works, i.e., CIs green except for the clang-format checker being red: c8de1e4
- [ ] Push second commit with `[actions format]` that runs the formatter, see CIs green: 
- [ ] Use rebase+merge (*not* squash+merge) to merge PR

Separate PR:

- [ ] Follow https://github.com/numpy/numpydoc/pull/394 to skip the autoformat commit in `blame`