### PR TITLE
Assert rework

### DIFF
--- a/OpenMEEGMaths/include/OMassert.H
+++ b/OpenMEEGMaths/include/OMassert.H
@@ -34,6 +34,5 @@
 
 inline void Assert(const char* assertion,const char* file,const unsigned line,const char* function) {
     std::cerr << file << ':' << line << ':' << function << ": Assertion `" << assertion << "' failed." << std::endl;
-    if (!assertion)
-        throw std::invalid_argument(assertion);
+    throw std::invalid_argument(assertion);
 }

--- a/tests/test_mesh_ios.cpp
+++ b/tests/test_mesh_ios.cpp
@@ -38,7 +38,10 @@ int main(int argc,char** argv) {
 
     Mesh mesh;
 
-    // // TRI
+    // Test that saving and reloading the mesh in several file formats provides
+    // an identical result.
+
+    // TRI
 
     mesh_orig.save("tmp.tri");
     mesh.load("tmp.tri");


### PR DESCRIPTION
When doing something else, I made some index error and saw that assert never throws the intended exception 
(so that we get tons of messages).

This was hiding a bug in the mesh file format (from BrainVisa I guess) reader, which I attempted to correct, but I do not find the documentation for that file format (broken link in an old BrainVisa forum). So I had to improvise. I ended supposing that the reader was correct and the writer not. Checked that I could read an old brainvisa .mesh file I had on a disk. I guess that if the reader was wrong, there is zero chance that om_mesh_info would say "Mesh orientation correct (valid for closed mesh)."

If you know a reader (in mne python ?) or a documentation for that format , I'd be happy to check I made the right choice.
That also probably means that no-one is using the .mesh file format writer in our users.... But for backward compatibility, I prefer to keep the support (the reader was not buggy so people may have used it without troubles).
