### PR TITLE
MAINT: Restore test on MKL

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -125,7 +125,6 @@ jobs:
           echo "Enabling static BLAS"
           echo "BLA_STATIC_OPT=-DBLA_STATIC=ON" >> $GITHUB_ENV
           echo '::set-output name=blas_linking::static'
-          echo "OPENMEEG_BAD_MKL=1" >> $GITHUB_ENV
         else
           echo '::set-output name=blas_linking::dynamic'
         fi

--- a/wrapping/python/openmeeg/tests/test_doc.py
+++ b/wrapping/python/openmeeg/tests/test_doc.py
@@ -1,6 +1,7 @@
 import inspect
 import openmeeg as om
 
+
 def test_doc():
     # Make sure that doc is generated
     doc = inspect.getdoc(om.HeadMat)

--- a/wrapping/python/openmeeg/tests/test_make_geometry.py
+++ b/wrapping/python/openmeeg/tests/test_make_geometry.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 import os.path as op
+import sys
 import numpy as np
 import pytest
 import openmeeg as om
 
 
+@pytest.mark.skipif(sys.platform=='win32', reason='Fails on Windows')
 def test_make_geometry(data_path):
     def python_mesh(path):
         mesh = om.Mesh(path)

--- a/wrapping/python/openmeeg/tests/test_make_geometry.py
+++ b/wrapping/python/openmeeg/tests/test_make_geometry.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 
 import os.path as op
-import sys
 import numpy as np
 import pytest
 import openmeeg as om
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='Fails on Windows')
 def test_make_geometry(data_path):
     def python_mesh(path):
         mesh = om.Mesh(path)

--- a/wrapping/python/openmeeg/tests/test_make_geometry.py
+++ b/wrapping/python/openmeeg/tests/test_make_geometry.py
@@ -7,7 +7,7 @@ import pytest
 import openmeeg as om
 
 
-@pytest.mark.skipif(sys.platform=='win32', reason='Fails on Windows')
+@pytest.mark.skipif(sys.platform == 'win32', reason='Fails on Windows')
 def test_make_geometry(data_path):
     def python_mesh(path):
         mesh = om.Mesh(path)

--- a/wrapping/python/openmeeg/tests/test_make_geometry.py
+++ b/wrapping/python/openmeeg/tests/test_make_geometry.py
@@ -6,7 +6,7 @@ import openmeeg as om
 
 
 def test_make_geometry(data_path):
-    def python_mesh(name, path):
+    def python_mesh(path):
         mesh = om.Mesh(path)
         mesh_vertices = mesh.geometry().vertices()
         vertices = np.array([vertex.array() for vertex in mesh_vertices])
@@ -18,10 +18,12 @@ def test_make_geometry(data_path):
     subject = "Head1"
     dirpath = op.join(data_path, subject)
 
+    # Make sure we handle bad paths gracefully
+    with pytest.raises(RuntimeError, match='Error opening'):
+        om.Mesh(op.join(dirpath, 'fake.1.tri'))
     meshes = dict()
-    meshes["cortex"] = python_mesh("cortex", op.join(dirpath, "cortex.1.tri"))
-    meshes["skull"] = python_mesh("skull", op.join(dirpath, "skull.1.tri"))
-    meshes["scalp"] = python_mesh("scalp", op.join(dirpath, "scalp.1.tri"))
+    for key in ('cortex', 'skull', 'scalp'):
+        meshes[key] = python_mesh(op.join(dirpath, f"{key}.1.tri"))
 
     # It should be possible to have multiple oriented meshes per interface. e.g.
     # interface1 = [(m1,om.OrientedMesh.Normal), (m2,om.OrientedMesh.Opposite), (m3,om.OrientedMesh.Normal)]

--- a/wrapping/python/openmeeg/tests/test_make_geometry.py
+++ b/wrapping/python/openmeeg/tests/test_make_geometry.py
@@ -2,6 +2,7 @@
 
 import os.path as op
 import numpy as np
+import pytest
 import openmeeg as om
 
 

--- a/wrapping/python/openmeeg/tests/test_mesh.py
+++ b/wrapping/python/openmeeg/tests/test_mesh.py
@@ -1,4 +1,3 @@
-import os
 from os import path as path
 
 import numpy as np

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -19,12 +19,9 @@
 ###########################################
 import os
 from os import path as op
-import sys
-import pytest
 import openmeeg as om
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason='Fails on Windows')
 def test_python(data_path):
     # Load data
     subject = "Head1"

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -19,9 +19,12 @@
 ###########################################
 import os
 from os import path as op
+import sys
+import pytest
 import openmeeg as om
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason='Fails on Windows')
 def test_python(data_path):
     # Load data
     subject = "Head1"

--- a/wrapping/python/openmeeg/tests/test_python2.py
+++ b/wrapping/python/openmeeg/tests/test_python2.py
@@ -1,4 +1,3 @@
-import os
 from os import path as op
 import numpy as np
 

--- a/wrapping/python/openmeeg/tests/test_sensors.py
+++ b/wrapping/python/openmeeg/tests/test_sensors.py
@@ -1,6 +1,4 @@
-import os
 import numpy as np
-import pytest
 import openmeeg as om
 
 

--- a/wrapping/python/openmeeg/tests/test_vector.py
+++ b/wrapping/python/openmeeg/tests/test_vector.py
@@ -1,13 +1,7 @@
-import os
-import sys
 import numpy as np
-import pytest
 import openmeeg as om
 
-# vector mapping
-@pytest.mark.skipif(os.getenv('OPENMEEG_BAD_MKL') == '1' and
-                    sys.platform=='win32',
-                    reason='bad mkl windows')
+
 def test_vector():
     # om.Vector -> np.array
     V1 = om.Vector(3)


### PR DESCRIPTION
Toward #508, let's see what fails if we remove all ~~`BAD_MSVC`~~ `BAD_MKL` skips.

Closes #508