### PR TITLE
MAINT: Remove PyPy test skips

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -116,9 +116,6 @@ jobs:
           echo '::set-output name=numpy_version::oldest'
         fi
         echo '::set-output name=python_version::${{matrix.python-version}}'
-        if [[ "${{matrix.python-version}}" == 'pypy'* ]]; then
-          echo "OPENMEEG_BAD_PYPY=1" >> $GITHUB_ENV
-        fi
         if [[ "${{matrix.blas_linking}}" == 'static' ]]; then
           echo "Enabling static BLAS"
           echo "BLA_STATIC_OPT=-DBLA_STATIC=ON" >> $GITHUB_ENV

--- a/build_tools/cibw_test_command.sh
+++ b/build_tools/cibw_test_command.sh
@@ -10,13 +10,9 @@ fi
 if [[ "$OPENMEEG_BAD_MSVC" == "" ]]; then
     export OPENMEEG_BAD_MSVC=$(python -c "import sys; print(int(sys.platform=='win32'))")
 fi
-if [[ "$OPENMEEG_BAD_PYPY" == "" ]]; then
-    export OPENMEEG_BAD_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
-fi
 TEST_PATH=$(python -c 'from pathlib import Path; import openmeeg; print(Path(openmeeg.__file__).parent)')
 echo "OPENMEEG_DATA_PATH=\"$OPENMEEG_DATA_PATH\""
 echo "OPENMEEG_BAD_MSVC=\"$OPENMEEG_BAD_MSVC\""
-echo "OPENMEEG_BAD_PYPY=\"$OPENMEEG_BAD_PYPY\""
 echo
 set -xe
 pytest -rav "$TEST_PATH"

--- a/wrapping/python/openmeeg/tests/test_mesh.py
+++ b/wrapping/python/openmeeg/tests/test_mesh.py
@@ -2,12 +2,9 @@ import os
 from os import path as path
 
 import numpy as np
-import pytest
 import openmeeg as om
 
 
-@pytest.mark.skipif(os.getenv('OPENMEEG_BAD_PYPY') == '1',
-                    reason="bug with PyPy support")
 def test_mesh_full(data_path):
     def test_mesh(name, vertices, triangles, expected_result):
         try:


### PR DESCRIPTION
Toward https://github.com/openmeeg/openmeeg/issues/508, let's see what fails if we remove all BAD_PYPY skips.