### PR TITLE
Improved Python error handling

### DIFF
--- a/wrapping/python/openmeeg/openmeeg.i
+++ b/wrapping/python/openmeeg/openmeeg.i
@@ -4,6 +4,9 @@
 
 %inline %{
 
+    #include <string>
+    #include <exception>
+
     class Error: public std::exception {
     public:
 


### PR DESCRIPTION
Calling PyErr_SetString does not interrupt the program flow, so does not generate the expected exception. The program was continuing so eventually not even generating an error or not the first one. This happened when an "extend" was calling other "extend" functions/methods. Instead, I introduced exceptions and let the swig mechanism to handle exceptions to deal with those.

The messages are also improved, so instead of and uninformative runtime error (because for some reason the PyErr_SetString message was lost), we now get:
>>> mesh1 = om.Mesh(np.array([[0.0, 0.0, 0.0]]), triangles)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/papadop/compiles/OpenMEEG/OpenMEEG-ref-f36/wrapping/python/openmeeg/openmeeg.py", line 1306, in __init__
    _openmeeg.Mesh_swiginit(self, _openmeeg.new_Mesh(*args))
ValueError: Vertex index 1 of triangle 0 out of range

I converted TypeError messages into ValueError messages because the former was giving a stack trace that did not seem very meaningful ti me, but if a python expert tells me a better type, it is easy to change that....
