### PR TITLE
Remove no longer useful pragmas.

### DIFF
--- a/OpenMEEG/include/DataTag.H
+++ b/OpenMEEG/include/DataTag.H
@@ -62,14 +62,8 @@ namespace Types {
     //  If not it raises an exception.
     //  This methods can be overloaded for more specific behaviours.
 
-#ifdef WIN32
-#pragma warning (disable: 4290)	// this particular throw is not the one Visual 2005 is waiting for
-#endif
     template <typename T>
     std::istream& operator>>(std::istream& is,Types::DataTag<T>& tag) {
-#ifdef WIN32
-#pragma warning (default: 4290)
-#endif
         bool DataP;
         is >> io_utils::match_optional(tag.tag(),DataP);
 

--- a/OpenMEEG/include/commandline.h
+++ b/OpenMEEG/include/commandline.h
@@ -46,11 +46,7 @@ knowledge of the CeCILL-B license and that you accept its terms.
 #include <sstream>
 #include <initializer_list>
 
-#ifdef WIN32
-#pragma warning( disable : 4530)    //MSVC standard library can't be inlined
-#pragma warning( disable : 4996)    //MSVC warning C4996: declared deprecated
-#pragma warning( disable : 4290)    //MSVC warning C4290: C++ exception specification
-#else
+#ifndef WIN32
 #define use_color_terminal
 #endif
 

--- a/OpenMEEGMaths/include/MathsIO.H
+++ b/OpenMEEGMaths/include/MathsIO.H
@@ -50,10 +50,6 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 #include <Exceptions.H>
 
-#ifdef WIN32
-#pragma warning( disable : 4290)    //MSVC warning C4290
-#endif
-
 namespace OpenMEEG {
     namespace maths {
 

--- a/OpenMEEGMaths/include/OpenMEEGMathsConfig.h
+++ b/OpenMEEGMaths/include/OpenMEEGMathsConfig.h
@@ -46,26 +46,24 @@ knowledge of the CeCILL-B license and that you accept its terms.
 
 // specially for windows
 #ifdef WIN32
-    #pragma inline_recursion (on)
-    #pragma inline_depth (255) // MSVC static build with MKL cause LNK2019 error
-    #pragma warning( disable : 4530)    //MSVC standard library can't be inlined
-    #pragma warning( disable : 4996)    //MSVC warning C4996: declared deprecated
+    #pragma inline_recursion(on)
+    #pragma inline_depth(255) // MSVC static build with MKL cause LNK2019 error
     #if defined(_MSC_VER)
         // Enable MSVC compiler warning messages that are useful but off by default.
-        # pragma warning ( default : 4263 ) /* no override, call convention differs */
+        #pragma warning(default : 4263) /* no override, call convention differs */
         // Disable MSVC compiler warning messages that often occur in valid code.
-        # pragma warning ( disable : 4097 ) /* typedef is synonym for class */
-        # pragma warning ( disable : 4127 ) /* conditional expression is constant */
-        # pragma warning ( disable : 4244 ) /* possible loss in conversion */
-        # pragma warning ( disable : 4251 ) /* missing DLL-interface */
-        # pragma warning ( disable : 4305 ) /* truncation from type1 to type2 */
-        # pragma warning ( disable : 4309 ) /* truncation of constant value */
-        # pragma warning ( disable : 4514 ) /* unreferenced inline function */
-        # pragma warning ( disable : 4706 ) /* assignment in conditional expression */
-        # pragma warning ( disable : 4710 ) /* function not inlined */
-        # pragma warning ( disable : 4786 ) /* identifier truncated in debug info */
-        # pragma warning ( disable : 4244 ) /* possible loss of data ('float' to 'mat_uint32_t') */
-        # pragma warning ( disable : 4267 ) /* possible loss of data (size_t to int) */
+        #pragma warning(disable : 4097) /* typedef is synonym for class */
+        #pragma warning(disable : 4127) /* conditional expression is constant */
+        #pragma warning(disable : 4244) /* possible loss in conversion */
+        #pragma warning(disable : 4251) /* missing DLL-interface */
+        #pragma warning(disable : 4305) /* truncation from type1 to type2 */
+        #pragma warning(disable : 4309) /* truncation of constant value */
+        #pragma warning(disable : 4514) /* unreferenced inline function */
+        #pragma warning(disable : 4706) /* assignment in conditional expression */
+        #pragma warning(disable : 4710) /* function not inlined */
+        #pragma warning(disable : 4786) /* identifier truncated in debug info */
+        #pragma warning(disable : 4244) /* possible loss of data ('float' to 'mat_uint32_t') */
+        #pragma warning(disable : 4267) /* possible loss of data (size_t to int) */
     #endif
 #endif
 


### PR DESCRIPTION
I noticed that some of the windows pragmas are related to old stuff that was removed years ago (exception specifications, ...). Trying to remove some of those (Removing even more WIN32 material)....