### PR TITLE
MAINT: Correct code for black and flake8

### DIFF
--- a/wrapping/python/openmeeg/_distributor_init.py
+++ b/wrapping/python/openmeeg/_distributor_init.py
@@ -4,20 +4,21 @@ import os
 import sys
 import platform
 
-if os.name == 'nt':
+if os.name == "nt":
     from ctypes import WinDLL
     import glob
+
     libs_path = os.path.abspath(os.path.join(os.path.dirname(__file__)))
     try:
         owd = os.getcwd()
         os.chdir(libs_path)
-        for filename in glob.glob(os.path.join(libs_path, '.libs', '*dll')):
+        for filename in glob.glob(os.path.join(libs_path, ".libs", "*dll")):
             WinDLL(os.path.abspath(filename))
     finally:
         os.chdir(owd)
-elif sys.platform == 'darwin' and platform.machine() == 'arm64':
+elif sys.platform == "darwin" and platform.machine() == "arm64":
     # On arm64 macOS the OpenBLAS runtimes of NumPy and SciPy don't seem to work
     # well together unless this timeout limit is set - it results in very slow
     # performance for some linalg functionality.
     # See https://github.com/scipy/scipy/issues/15050 for details.
-    os.environ['OPENBLAS_THREAD_TIMEOUT'] = '1'
+    os.environ["OPENBLAS_THREAD_TIMEOUT"] = "1"

--- a/wrapping/python/openmeeg/_make_geometry.py
+++ b/wrapping/python/openmeeg/_make_geometry.py
@@ -22,17 +22,20 @@ def make_geometry(meshes, interfaces, domains):
     if not isinstance(meshes, dict) or len(meshes) == 0:
         raise ValueError(
             "Wrong argument (should be a non empty dictionary of named "
-            "meshes). Got {type(meshes)}")
+            "meshes). Got {type(meshes)}"
+        )
 
     if not isinstance(interfaces, dict) or len(interfaces) == 0:
         raise ValueError(
             "Wrong argument (should be a non empty dictionary of named "
-            f"interfaces). Got {type(interfaces)}")
+            f"interfaces). Got {type(interfaces)}"
+        )
 
     if not isinstance(domains, dict) or len(domains) == 0:
         raise ValueError(
             "Wrong argument (should be a non empty dictionary of named "
-            f"domains). Got {type(domains)}")
+            f"domains). Got {type(domains)}"
+        )
 
     # First add mesh points
 
@@ -51,11 +54,11 @@ def make_geometry(meshes, interfaces, domains):
     for dname, domain in domains.items():
         domain_interfaces, conductivity = domain
 
-        if not isinstance(domain_interfaces, list) or \
-                len(domain_interfaces) == 0:
+        if not isinstance(domain_interfaces, list) or len(domain_interfaces) == 0:
             raise Exception(
                 f"wrong description of domain ({dname}), should be a "
-                "non-empty list of interfaces")
+                "non-empty list of interfaces"
+            )
 
         om_domain = Domain(dname)
         om_domain.set_conductivity(conductivity)
@@ -63,24 +66,30 @@ def make_geometry(meshes, interfaces, domains):
         for iname, side in domain_interfaces:
             if iname not in interfaces:
                 raise Exception(
-                    f"Domain {dname} contains and unknown interface {iname}.")
+                    f"Domain {dname} contains and unknown interface {iname}."
+                )
             oriented_meshes = interfaces[iname]
             if type(oriented_meshes) != list or len(oriented_meshes) == 0:
                 raise Exception(
                     f"Interface definition {iname} first argument should be a "
-                    "non-empty list of (mesh,orientation)")
+                    "non-empty list of (mesh,orientation)"
+                )
             if side != SimpleDomain.Inside and side != SimpleDomain.Outside:
                 raise Exception(
                     f"Domain {dname}: interface {iname} has a wrong side "
-                    "direction (In/Out)")
+                    "direction (In/Out)"
+                )
 
             om_interface = Interface(iname)
             for mesh_name, orientation in oriented_meshes:
-                if orientation != OrientedMesh.Normal and \
-                        orientation != OrientedMesh.Opposite:
+                if (
+                    orientation != OrientedMesh.Normal
+                    and orientation != OrientedMesh.Opposite
+                ):
                     raise Exception(
                         f"Wrong description for interface ({iname}), second "
-                        "tuple member should a be an orientation")
+                        "tuple member should a be an orientation"
+                    )
 
                 mesh = geom.mesh(mesh_name)
                 oriented_mesh = OrientedMesh(mesh, orientation)

--- a/wrapping/python/openmeeg/_version.py
+++ b/wrapping/python/openmeeg/_version.py
@@ -1,1 +1,1 @@
-__version__ = '2.4.8.dev0'
+__version__ = "2.4.8.dev0"

--- a/wrapping/python/openmeeg/tests/conftest.py
+++ b/wrapping/python/openmeeg/tests/conftest.py
@@ -2,14 +2,13 @@ import os
 import pytest
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def data_path():
-    data_path = os.getenv('OPENMEEG_DATA_PATH')
-    assert data_path is not None, 'OPENMEEG_DATA_PATH must be set, got None'
+    data_path = os.getenv("OPENMEEG_DATA_PATH")
+    assert data_path is not None, "OPENMEEG_DATA_PATH must be set, got None"
     # deal with MSVC not handling mixed paths like
     # D:/a/openmeeg/openmeeg/data\Head1\Head1.geom
     # but cmake uses a mixed path for the --path arg
-    data_path = data_path.replace('/', os.path.sep)
-    assert os.path.isdir(data_path), \
-        f'OPENMEEG_DATA_PATH does not exist: ${data_path}'
+    data_path = data_path.replace("/", os.path.sep)
+    assert os.path.isdir(data_path), f"OPENMEEG_DATA_PATH does not exist: ${data_path}"
     return data_path

--- a/wrapping/python/openmeeg/tests/test_doc.py
+++ b/wrapping/python/openmeeg/tests/test_doc.py
@@ -7,6 +7,9 @@ def test_doc():
     doc = inspect.getdoc(om.HeadMat)
     assert doc is not None
 
-    headmat_expected_docstring = \
-        ("HeadMat(Geometry geo, Integrator const & integrator=Integrator(3,0,0.005)) -> SymMatrix")
-    assert doc == headmat_expected_docstring, f'got: {repr(doc)} != expected: {repr(headmat_expected_docstring)}'
+    headmat_expected_docstring = """\
+HeadMat(Geometry geo, Integrator const & integrator=Integrator(3,0,0.005)) \
+-> SymMatrix"""
+    assert (
+        doc == headmat_expected_docstring
+    ), f"got: {repr(doc)} != expected: {repr(headmat_expected_docstring)}"

--- a/wrapping/python/openmeeg/tests/test_geom.py
+++ b/wrapping/python/openmeeg/tests/test_geom.py
@@ -6,8 +6,9 @@ import openmeeg as om
 
 
 def test_geometry():
-    vertices = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0],
-                        [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]]
+    )
     triangles = np.array([[1, 2, 3], [2, 3, 0]])
 
     g = om.Geometry()
@@ -15,20 +16,20 @@ def test_geometry():
 
     assert mesh.geometry().check(mesh)
 
-    with pytest.raises(TypeError, match='should be an array'):
-        g.add_vertices('foo')
-    with pytest.raises(ValueError, match='Vertices.*cannot be converted'):
+    with pytest.raises(TypeError, match="should be an array"):
+        g.add_vertices("foo")
+    with pytest.raises(ValueError, match="Vertices.*cannot be converted"):
         g.add_vertices(np.array([1j]))
-    with pytest.raises(ValueError, match='Vertices.*2 dim.*3 columns'):
-        g.add_vertices(np.array([0.]))
-    with pytest.raises(ValueError, match='Vertices.*2 dim.*3 columns'):
-        g.add_vertices(np.array([[0.]]))
+    with pytest.raises(ValueError, match="Vertices.*2 dim.*3 columns"):
+        g.add_vertices(np.array([0.0]))
+    with pytest.raises(ValueError, match="Vertices.*2 dim.*3 columns"):
+        g.add_vertices(np.array([[0.0]]))
     # TODO should be IOError and have a better error message
-    with pytest.raises(RuntimeError, match='Unknown foo suffix'):
-        om.Geometry('a.foo')
-    with pytest.raises(TypeError, match='Argument.*must be a list'):
+    with pytest.raises(RuntimeError, match="Unknown foo suffix"):
+        om.Geometry("a.foo")
+    with pytest.raises(TypeError, match="Argument.*must be a list"):
         om.Geometry(())
-    with pytest.raises(TypeError, match='must be a list of lists'):
+    with pytest.raises(TypeError, match="must be a list of lists"):
         om.Geometry([()])
-    with pytest.raises(TypeError, match='first entry a non-empty'):
+    with pytest.raises(TypeError, match="first entry a non-empty"):
         om.Geometry([[0, np.zeros((1, 3)), 0]])

--- a/wrapping/python/openmeeg/tests/test_make_geometry.py
+++ b/wrapping/python/openmeeg/tests/test_make_geometry.py
@@ -12,7 +12,9 @@ def test_make_geometry(data_path):
         mesh_vertices = mesh.geometry().vertices()
         vertices = np.array([vertex.array() for vertex in mesh_vertices])
         mesh_triangles = mesh.triangles()
-        triangles = np.array([mesh.triangle(triangle).array() for triangle in mesh_triangles])
+        triangles = np.array(
+            [mesh.triangle(triangle).array() for triangle in mesh_triangles]
+        )
         return vertices, triangles
 
     # Load mesh data to mimic Head1.geom + Head1.cond
@@ -20,32 +22,48 @@ def test_make_geometry(data_path):
     dirpath = op.join(data_path, subject)
 
     # Make sure we handle bad paths gracefully
-    with pytest.raises(RuntimeError, match='Error opening'):
-        om.Mesh(op.join(dirpath, 'fake.1.tri'))
+    with pytest.raises(RuntimeError, match="Error opening"):
+        om.Mesh(op.join(dirpath, "fake.1.tri"))
     meshes = dict()
-    for key in ('cortex', 'skull', 'scalp'):
+    for key in ("cortex", "skull", "scalp"):
         meshes[key] = python_mesh(op.join(dirpath, f"{key}.1.tri"))
 
     # It should be possible to have multiple oriented meshes per interface. e.g.
-    # interface1 = [(m1,om.OrientedMesh.Normal), (m2,om.OrientedMesh.Opposite), (m3,om.OrientedMesh.Normal)]
+    # interface1 = [(m1,om.OrientedMesh.Normal),
+    #               (m2,om.OrientedMesh.Opposite),
+    #               (m3,om.OrientedMesh.Normal)]
     # It should also be possible to have a name added at the beginning of the
     # tuple.
 
     interfaces = {
-        "interface1": [('cortex', om.OrientedMesh.Normal)],
-        "interface2": [('skull', om.OrientedMesh.Normal)],
-        "interface3": [('scalp', om.OrientedMesh.Normal)]
+        "interface1": [("cortex", om.OrientedMesh.Normal)],
+        "interface2": [("skull", om.OrientedMesh.Normal)],
+        "interface3": [("scalp", om.OrientedMesh.Normal)],
     }
 
     domains = {
-        "Scalp": ([('interface2', om.SimpleDomain.Outside), ('interface3', om.SimpleDomain.Inside)], 1.0),
-        "Brain": ([('interface1', om.SimpleDomain.Inside)], 1.0),
-        "Air": ([('interface3', om.SimpleDomain.Outside)], 0.0),
-        "Skull": ([('interface2', om.SimpleDomain.Inside), ('interface1', om.SimpleDomain.Outside)], 0.0125)
+        "Scalp": (
+            [
+                ("interface2", om.SimpleDomain.Outside),
+                ("interface3", om.SimpleDomain.Inside),
+            ],
+            1.0,
+        ),
+        "Brain": ([("interface1", om.SimpleDomain.Inside)], 1.0),
+        "Air": ([("interface3", om.SimpleDomain.Outside)], 0.0),
+        "Skull": (
+            [
+                ("interface2", om.SimpleDomain.Inside),
+                ("interface1", om.SimpleDomain.Outside),
+            ],
+            0.0125,
+        ),
     }
 
     g1 = om.make_geometry(meshes, interfaces, domains)
-    g2 = om.Geometry(op.join(dirpath, subject + ".geom"), op.join(dirpath, subject + ".cond"))
+    g2 = om.Geometry(
+        op.join(dirpath, subject + ".geom"), op.join(dirpath, subject + ".cond")
+    )
 
     assert g1.is_nested()
     assert g2.is_nested()

--- a/wrapping/python/openmeeg/tests/test_matrix.py
+++ b/wrapping/python/openmeeg/tests/test_matrix.py
@@ -51,16 +51,16 @@ def test_matrix():
     # mimic info()
 
     print("First Values of numpy array")
-    for l in range(5):
-        for c in range(5):
-            print(mat_numpy[l, c], end=" ")
+    for li in range(5):
+        for ci in range(5):
+            print(mat_numpy[li, ci], end=" ")
         print()
 
     error = False
-    for l in range(5):
-        for c in range(5):
-            if mat_numpy[l, c] != mat_om.value(l, c):
-                print("matrices differ at:", l, c)
+    for li in range(5):
+        for ci in range(5):
+            if mat_numpy[li, ci] != mat_om.value(li, ci):
+                print("matrices differ at:", li, ci)
                 error = True
 
     if error:

--- a/wrapping/python/openmeeg/tests/test_mesh.py
+++ b/wrapping/python/openmeeg/tests/test_mesh.py
@@ -9,7 +9,7 @@ def test_mesh_full(data_path):
         try:
             mesh = om.Mesh(vertices, triangles)
             mesh.info()
-        except:
+        except Exception:
             if expected_result:
                 print("Test", name, "--> Failed")
                 assert False
@@ -21,8 +21,9 @@ def test_mesh_full(data_path):
             assert False
         print("Test", name, "--> Expected success")
 
-    vertices = np.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0],
-                        [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]])
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]]
+    )
     triangles = np.array([[1, 2, 3], [2, 3, 0]])
 
     test_mesh("1", vertices, triangles, True)

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -71,7 +71,6 @@ def test_python(data_path):
         geom, dipoles, hm, h2em, h2mm, ds2mm
     )
 
-
     print("hm                  : %d x %d" % (hm.nlin(), hm.ncol()))
     print("hminv               : %d x %d" % (hminv.nlin(), hminv.ncol()))
     print("ssm                 : %d x %d" % (ssm.nlin(), ssm.ncol()))
@@ -81,23 +80,17 @@ def test_python(data_path):
     print("h2mm                : %d x %d" % (h2mm.nlin(), h2mm.ncol()))
     print("h2em                : %d x %d" % (h2mm.nlin(), h2mm.ncol()))
     print(
-        "gain_meg_surf       : %d x %d"
-        % (gain_meg_surf.nlin(), gain_meg_surf.ncol())
+        "gain_meg_surf       : %d x %d" % (gain_meg_surf.nlin(), gain_meg_surf.ncol())
     )
     print(
-        "gain_eeg_surf       : %d x %d"
-        % (gain_eeg_surf.nlin(), gain_eeg_surf.ncol())
+        "gain_eeg_surf       : %d x %d" % (gain_eeg_surf.nlin(), gain_eeg_surf.ncol())
     )
-    print(
-        "gain_meg_dip        : %d x %d" % (gain_meg_dip.nlin(), gain_meg_dip.ncol())
-    )
+    print("gain_meg_dip        : %d x %d" % (gain_meg_dip.nlin(), gain_meg_dip.ncol()))
     print(
         "gain_adjoint_meg_dip: %d x %d"
         % (gain_adjoint_meg_dip.nlin(), gain_adjoint_meg_dip.ncol())
     )
-    print(
-        "gain_eeg_dip        : %d x %d" % (gain_eeg_dip.nlin(), gain_eeg_dip.ncol())
-    )
+    print("gain_eeg_dip        : %d x %d" % (gain_eeg_dip.nlin(), gain_eeg_dip.ncol()))
     print(
         "gain_adjoint_eeg_dip: %d x %d"
         % (gain_adjoint_eeg_dip.nlin(), gain_adjoint_eeg_dip.ncol())

--- a/wrapping/python/openmeeg/tests/test_sensors.py
+++ b/wrapping/python/openmeeg/tests/test_sensors.py
@@ -4,8 +4,8 @@ import openmeeg as om
 
 def test_sensors():
     labels = ["toto"]
-    positions = np.array([[0, 1, 2], [0, 1, 2]], order='F')
-    orientations = np.array([[-1, -1, -2], [-1, -1, -2]], order='F')
+    positions = np.array([[0, 1, 2], [0, 1, 2]], order="F")
+    orientations = np.array([[-1, -1, -2], [-1, -1, -2]], order="F")
     weights = np.array([0.5, 0.5])
     radii = np.array([1, 1])
     s1 = om.Sensors(labels, positions, orientations, weights, radii)

--- a/wrapping/python/openmeeg/tests/test_vector.py
+++ b/wrapping/python/openmeeg/tests/test_vector.py
@@ -42,8 +42,8 @@ def test_vector():
     print("conversion between OpenMEEG:Vector <> numpy.array is OK")
 
     # degenerate cases
-    with pytest.raises(TypeError, match='Input object is neither.*Vector'):
-        om.Vector('foo')
+    with pytest.raises(TypeError, match="Input object is neither.*Vector"):
+        om.Vector("foo")
     vec = om.Vector(3)
-    with pytest.raises(IndexError, match='Index out of range'):
+    with pytest.raises(IndexError, match="Index out of range"):
         vec.value(3)

--- a/wrapping/python/setup.py
+++ b/wrapping/python/setup.py
@@ -14,22 +14,22 @@ from setuptools.command import build_py
 root = Path(__file__).parent
 
 version = None
-with open((root / 'openmeeg' / '_version.py'), 'r') as fid:
+with open((root / "openmeeg" / "_version.py"), "r") as fid:
     for line in (line.strip() for line in fid):
-        if line.startswith('__version__'):
-            version = line.split('=')[1].strip().strip('\'')
+        if line.startswith("__version__"):
+            version = line.split("=")[1].strip().strip('"')
             break
 if version is None:
-    raise RuntimeError('Could not determine version')
+    raise RuntimeError("Could not determine version")
 
 
-DISTNAME = 'openmeeg'
-DESCRIPTION = 'Forward problems solver in the field of EEG and MEG.'
-MAINTAINER = 'Alexandre Gramfort'
-MAINTAINER_EMAIL = 'alexandre.gramfort@inria.fr'
-URL = 'https://openmeeg.github.io/'
-LICENSE = 'CECILL-B'
-DOWNLOAD_URL = 'http://github.com/openmeeg/openmeeg'
+DISTNAME = "openmeeg"
+DESCRIPTION = "Forward problems solver in the field of EEG and MEG."
+MAINTAINER = "Alexandre Gramfort"
+MAINTAINER_EMAIL = "alexandre.gramfort@inria.fr"
+URL = "https://openmeeg.github.io/"
+LICENSE = "CECILL-B"
+DOWNLOAD_URL = "http://github.com/openmeeg/openmeeg"
 VERSION = version
 
 # Adapted from MIT-licensed
@@ -38,7 +38,6 @@ try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
     class bdist_wheel(_bdist_wheel):
-
         def finalize_options(self):
             _bdist_wheel.finalize_options(self)
             # Mark us as not a pure python package
@@ -55,47 +54,47 @@ class BuildExtFirst(build_py.build_py):
         super().run()
 
 
-
 if __name__ == "__main__":
     import numpy as np
-    manifest = (root / 'MANIFEST')
+
+    manifest = root / "MANIFEST"
     if manifest.is_file():
         os.remove(manifest)
 
-    with open('README.rst', 'r') as fid:
+    with open("README.rst", "r") as fid:
         long_description = fid.read()
 
     # SWIG
     cmdclass = dict(build_py=BuildExtFirst)
     ext_modules = []
-    if os.getenv('OPENMEEG_USE_SWIG', '0').lower() in ('1', 'true'):
+    if os.getenv("OPENMEEG_USE_SWIG", "0").lower() in ("1", "true"):
         include_dirs = [np.get_include()]
-        swig_opts = ['-c++', '-v', '-O']  # TODO: , '-Werror']
+        swig_opts = ["-c++", "-v", "-O"]  # TODO: , '-Werror']
         library_dirs = []
-        openmeeg_include = os.getenv('OPENMEEG_INCLUDE')
+        openmeeg_include = os.getenv("OPENMEEG_INCLUDE")
         if openmeeg_include is not None:
             openmeeg_include = Path(openmeeg_include).resolve()
             assert openmeeg_include.is_dir(), openmeeg_include
             include_dirs.append(str(openmeeg_include))
-            swig_opts.append(f'-I{openmeeg_include}')
-        msvc = os.getenv('SWIG_FLAGS', '') == 'msvc'
-        openblas_include = os.getenv('OPENBLAS_INCLUDE')
+            swig_opts.append(f"-I{openmeeg_include}")
+        msvc = os.getenv("SWIG_FLAGS", "") == "msvc"
+        openblas_include = os.getenv("OPENBLAS_INCLUDE")
         if openblas_include is not None:
             openblas_include = Path(openblas_include).resolve()
             assert openblas_include.is_dir(), openblas_include
             include_dirs.append(str(openblas_include))
-            swig_opts.append(f'-I{openblas_include}')
-        openmeeg_lib = os.getenv('OPENMEEG_LIB')
+            swig_opts.append(f"-I{openblas_include}")
+        openmeeg_lib = os.getenv("OPENMEEG_LIB")
         if openmeeg_lib is not None:
             openmeeg_lib = Path(openmeeg_lib).resolve()
             assert openmeeg_lib.is_dir(), openmeeg_lib
             library_dirs.append(str(openmeeg_lib))
         extra_compile_opts, extra_link_opts = [], []
         if msvc:
-            extra_compile_opts.extend(['/std:c++17'])
-            extra_link_opts.extend(['/std:c++17'])
+            extra_compile_opts.extend(["/std:c++17"])
+            extra_link_opts.extend(["/std:c++17"])
         else:
-            extra_compile_opts.extend(['-v', '-std=c++17'])
+            extra_compile_opts.extend(["-v", "-std=c++17"])
         # An example cmake command that works is:
         #   C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.16.27023\bin\HostX64\x64\link.exe
         #     /ERRORREPORT:QUEUE /INCREMENTAL:NO /NOLOGO
@@ -110,11 +109,10 @@ if __name__ == "__main__":
         #     /c /nologo /O2 /W3 /GL /DNDEBUG /MD
         #     /EHsc /Tpopenmeeg/openmeeg_wrap.cpp /Fobuild\temp.win-amd64-cpython-310\Release\openmeeg/openmeeg_wrap.obj
 
-
         swig_openmeeg = Extension(
             "openmeeg._openmeeg",
             sources=["openmeeg/openmeeg.i"],
-            libraries=['OpenMEEG'],
+            libraries=["OpenMEEG"],
             swig_opts=swig_opts,
             extra_compile_args=extra_compile_opts,
             include_dirs=include_dirs,
@@ -123,43 +121,45 @@ if __name__ == "__main__":
         ext_modules.append(swig_openmeeg)
     else:  # built with -DENABLE_PYTHON=ON
         # TODO: This breaks macOS for some reason!
-        if sys.platform != 'darwin':
-            cmdclass['bdist_wheel'] = bdist_wheel
+        if sys.platform != "darwin":
+            cmdclass["bdist_wheel"] = bdist_wheel
 
-    setup(name=DISTNAME,
-          maintainer=MAINTAINER,
-          include_package_data=True,
-          maintainer_email=MAINTAINER_EMAIL,
-          description=DESCRIPTION,
-          license=LICENSE,
-          url=URL,
-          version=VERSION,
-          download_url=DOWNLOAD_URL,
-          long_description=long_description,
-          long_description_content_type='text/x-rst',
-          zip_safe=False,  # the package can run out of an .egg file
-          classifiers=['Intended Audience :: Science/Research',
-                       'Intended Audience :: Developers',
-                       'License :: OSI Approved',
-                       'Programming Language :: Python',
-                       'Topic :: Software Development',
-                       'Topic :: Scientific/Engineering',
-                       'Operating System :: Microsoft :: Windows',
-                       'Operating System :: POSIX',
-                       'Operating System :: Unix',
-                       'Operating System :: MacOS',
-                       'Programming Language :: Python :: 3',
-                       ],
-          keywords='neuroscience neuroimaging MEG EEG ECoG sEEG iEEG brain',
-          project_urls={
-              'Documentation': 'https://openmeeg.github.io',
-              'Source': 'https://github.com/openmeeg/openmeeg',
-              'Tracker': 'https://github.com/openmeeg/openmeeg/issues',
-          },
-          platforms='any',
-          python_requires='>=3.7',
-          install_requires=["numpy"],
-          packages=["openmeeg", "openmeeg.tests"],
-          cmdclass=cmdclass,
-          ext_modules=ext_modules,
-          )
+    setup(
+        name=DISTNAME,
+        maintainer=MAINTAINER,
+        include_package_data=True,
+        maintainer_email=MAINTAINER_EMAIL,
+        description=DESCRIPTION,
+        license=LICENSE,
+        url=URL,
+        version=VERSION,
+        download_url=DOWNLOAD_URL,
+        long_description=long_description,
+        long_description_content_type="text/x-rst",
+        zip_safe=False,  # the package can run out of an .egg file
+        classifiers=[
+            "Intended Audience :: Science/Research",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved",
+            "Programming Language :: Python",
+            "Topic :: Software Development",
+            "Topic :: Scientific/Engineering",
+            "Operating System :: Microsoft :: Windows",
+            "Operating System :: POSIX",
+            "Operating System :: Unix",
+            "Operating System :: MacOS",
+            "Programming Language :: Python :: 3",
+        ],
+        keywords="neuroscience neuroimaging MEG EEG ECoG sEEG iEEG brain",
+        project_urls={
+            "Documentation": "https://openmeeg.github.io",
+            "Source": "https://github.com/openmeeg/openmeeg",
+            "Tracker": "https://github.com/openmeeg/openmeeg/issues",
+        },
+        platforms="any",
+        python_requires=">=3.7",
+        install_requires=["numpy"],
+        packages=["openmeeg", "openmeeg.tests"],
+        cmdclass=cmdclass,
+        ext_modules=ext_modules,
+    )


### PR DESCRIPTION
Over in https://github.com/openmeeg/openmeeg/pull/553 I hit an error because we had no `flake8`-sort of checking going on (`pyflakes` would have caught it), so I want to add some Python style checks to CIs.

At the same time, many scientific Python groups are moving to `black` (NumPy, scikit-learn). It seems like a good time since there isn't too much Python code in the repo, and we can just standardize around it easily.

In this PR I'm:

1. changing the Python code to conform to these styles
2. adding a pre-commit hook that enables automatic `black` formatting if people want to `pre-commit install` it, but it's not required
3. adding CI checks for `black` and `flake8` compliance

This should go in after https://github.com/openmeeg/openmeeg/pull/553, hence the WIP