### PR TITLE
CI: Use black and flake8

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,14 @@
+# Adapted from scikit-learn
+
+# Since git version 2.23, git-blame has a feature to ignore
+# certain commits.
+#
+# This file contains a list of commits that are not likely what
+# you are looking for in `git blame`. You can set this file as
+# a default ignore file for blame by running the following
+# command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# MAINT: Correct code for black and flake8 #554
+88b8ff1c9f4e3b2e0631a91f479ebd72caa1120c

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,30 @@
+# This CI run checks for style compliance.
+
+name: Lint
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          src: "./wrapping/python"
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - run: pip install flake8
+      - uses: rbialon/flake8-annotations@v1
+      - run: flake8
+        working-directory: wrapping/python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black

--- a/wrapping/python/MANIFEST.in
+++ b/wrapping/python/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.py
 exclude *.cxx
+exclude setup.cfg
 include openmeeg/_openmeeg.*

--- a/wrapping/python/setup.cfg
+++ b/wrapping/python/setup.cfg
@@ -1,0 +1,7 @@
+[flake8]
+ignore = F841, W503
+per-file-ignores =
+    __init__.py:F401
+    setup.py:E501
+max-line-length = 88
+count = true


### PR DESCRIPTION
Second part of transitioning to black+flake8:

1. Add to CI
2. Add optional pre-commit hook support
3. Ignore the style commit in blame

Will mark for auto-merge and then add lint to the required CIs in branch protection rules