### PR TITLE
BUG: Force users to specify domain_name

### DIFF
--- a/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/include/assemble.h
@@ -24,13 +24,13 @@
 namespace OpenMEEG {
 
     // For ADAPT_LHS change the 0 in Integrator below into 10
-    // It would be nice to define some constant integrators for the default values but swig does not like them. 
+    // It would be nice to define some constant integrators for the default values but swig does not like them.
 
     OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3,0,0.005));
     OPENMEEG_EXPORT Matrix SurfSourceMat(const Geometry& geo,Mesh& sources,const Integrator& integrator=Integrator(3,0,0.005));
 
     OPENMEEG_EXPORT Matrix
-    DipSourceMat(const Geometry& geo,const Matrix& dipoles,const Integrator& integrator=Integrator(3,10,0.001),const std::string& domain_name="");
+    DipSourceMat(const Geometry& geo,const Matrix& dipoles,const Integrator& integrator,const std::string& domain_name);
     OPENMEEG_EXPORT Matrix
     DipSourceMat(const Geometry& geo,const Matrix& dipoles,const std::string& domain_name);
 

--- a/OpenMEEG/include/gain.h
+++ b/OpenMEEG/include/gain.h
@@ -79,7 +79,7 @@ namespace OpenMEEG {
             const Matrix& Hinv = linsolve(HeadMat,Head2EEGMat);
             ProgressBar pb(ncol());
             for (unsigned i=0; i<ncol(); ++i,++pb)
-                setcol(i,Hinv*DipSourceMat(geo,dipoles.submat(i,1,0,dipoles.ncol())).getcol(0)); // TODO ugly
+                setcol(i,Hinv*DipSourceMat(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").getcol(0)); // TODO ugly
         }
     };
 
@@ -89,12 +89,12 @@ namespace OpenMEEG {
         using Matrix::operator=;
 
         GainMEGadjoint(const Geometry& geo,const Matrix& dipoles,const SymMatrix& HeadMat,const Matrix& Head2MEGMat,const Matrix& Source2MEGMat):
-            Matrix(Head2MEGMat.nlin(),dipoles.nlin()) 
+            Matrix(Head2MEGMat.nlin(),dipoles.nlin())
         {
             const Matrix& Hinv = linsolve(HeadMat,Head2MEGMat);
             ProgressBar pb(ncol());
             for (unsigned i=0; i<ncol(); ++i,++pb)
-                setcol(i,Hinv*DipSourceMat(geo,dipoles.submat(i,1,0,dipoles.ncol())).getcol(0)+Source2MEGMat.getcol(i)); // TODO ugly
+                setcol(i,Hinv*DipSourceMat(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").getcol(0)+Source2MEGMat.getcol(i)); // TODO ugly
         }
     };
 
@@ -113,12 +113,12 @@ namespace OpenMEEG {
 
             ProgressBar pb(dipoles.nlin());
             for (unsigned i=0; i<dipoles.nlin(); ++i,++pb) {
-                const Vector& dsm = DipSourceMat(geo,dipoles.submat(i,1,0,dipoles.ncol())).getcol(0); // TODO ugly
+                const Vector& dsm = DipSourceMat(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").getcol(0); // TODO ugly
                 EEGleadfield.setcol(i,Hinv.submat(0,Head2EEGMat.nlin(),0,HeadMat.nlin())*dsm);
                 MEGleadfield.setcol(i,Hinv.submat(Head2EEGMat.nlin(),Head2MEGMat.nlin(),0,HeadMat.nlin())*dsm+Source2MEGMat.getcol(i));
             }
         }
-        
+
         void saveEEG( const std::string filename ) const { EEGleadfield.save(filename); }
         void saveMEG( const std::string filename ) const { MEGleadfield.save(filename); }
 

--- a/apps/assemble.cpp
+++ b/apps/assemble.cpp
@@ -133,7 +133,7 @@ int main(int argc, char** argv)
         assert_non_conflicting_options(argv[0],++num_options);
 
         // Computation of distributed Surface Source Matrix for BEM Symmetric formulation
-        
+
         const Geometry geo(opt_parms[1],opt_parms[2],use_old_ordering);
         Mesh mesh_sources(opt_parms[3]);
 
@@ -147,7 +147,7 @@ int main(int argc, char** argv)
         assert_non_conflicting_options(argv[0],++num_options);
 
         // Computation of RHS for discrete dipolar case
-    
+
         std::string domain_name = "";
         if (cmd.num_args(opt_parms)==5) {
             domain_name = opt_parms[6];
@@ -172,8 +172,8 @@ int main(int argc, char** argv)
 
         const char* optname = opt_parms[0];
         const unsigned integration_levels = check_no_adapt(optname,{"-DipSourceMatNoAdapt", "-DSMNA", "-dsmna"}) ? 0 : 10;
-        
-        const Matrix& dsm = DipSourceMat(geo,dipoles,Integrator(3,integration_levels,0.001));
+
+        const Matrix& dsm = DipSourceMat(geo,dipoles,Integrator(3,integration_levels,0.001),domain_name);
         dsm.save(opt_parms[4]);
     }
 

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -65,7 +65,7 @@ def test_python(data_path, tmp_path):
 
     ssm = om.SurfSourceMat(geom, mesh)
     ss2mm = om.SurfSource2MEGMat(mesh, sensors)
-    dsm = om.DipSourceMat(geom, dipoles)
+    dsm = om.DipSourceMat(geom, dipoles, "Brain")
     ds2mm = om.DipSource2MEGMat(dipoles, sensors)
     h2mm = om.Head2MEGMat(geom, sensors)
     h2em = om.Head2EEGMat(geom, patches)


### PR DESCRIPTION
@agramfort was just hit by a bug where `DipSourceMat` was not working properly because he didn't specify that `domain_name='brain'`. This PR makes the `domain_name` a mandatory argument, which seems safer than ~~allowing it to be~~ defaulting it to an empty string.