### PR TITLE
MAINT: Disable OpenMP on Windows for now

### DIFF
--- a/build_tools/cibw_before_all.sh
+++ b/build_tools/cibw_before_all.sh
@@ -82,6 +82,8 @@ elif [[ "$PLATFORM" == "win-amd64" ]]; then
     source ./build_tools/download_openblas.sh windows  # NumPy doesn't install the headers for Windows
     pip install delvewheel
     export SYSTEM_VERSION_OPT="-DCMAKE_SYSTEM_VERSION=7"
+    # OpenMP seems to cause problems on Windows, too, at least when used in conjunction with NumPy built with OpenMP-enabled OpenBLAS, etc.
+    OPENMP_OPT="-DUSE_OPENMP=OFF"
 else
     echo "Unknown platform: ${PLATFORM}"
     exit 1

--- a/wrapping/python/openmeeg/_version.py
+++ b/wrapping/python/openmeeg/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.6.0.dev0"
+__version__ = "2.6.0.dev1"


### PR DESCRIPTION
I'm going to tell the wheels not to use OpenMP, then merge. This will cause a testpypi upload, which we can then use in https://github.com/mne-tools/mne-python/pull/11011 where we have observed failures. If this comes back green for the run that uses the `testpypi` wheel (maybe after a restart or two?), we can conclude that something is wrong with our use of OpenMP on Windows that's causing the failures. We already had to disable it on macOS for @agramfort locally, so it wouldn't surprise me at all if this is the case.