### PR TITLE
ENH: Add verbose argument to HeadMat, expose Integrator

### DIFF
--- a/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/include/assemble.h
@@ -27,7 +27,6 @@ namespace OpenMEEG {
     // It would be nice to define some constant integrators for the default values but swig does not like them.
 
     OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
-    OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo, const bool verbose);
     OPENMEEG_EXPORT Matrix SurfSourceMat(const Geometry& geo,Mesh& sources,const Integrator& integrator=Integrator(3,0,0.005));
 
     OPENMEEG_EXPORT Matrix

--- a/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/include/assemble.h
@@ -26,7 +26,8 @@ namespace OpenMEEG {
     // For ADAPT_LHS change the 0 in Integrator below into 10
     // It would be nice to define some constant integrators for the default values but swig does not like them.
 
-    OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3,0,0.005));
+    OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
+    OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo, const bool verbose);
     OPENMEEG_EXPORT Matrix SurfSourceMat(const Geometry& geo,Mesh& sources,const Integrator& integrator=Integrator(3,0,0.005));
 
     OPENMEEG_EXPORT Matrix
@@ -53,8 +54,8 @@ namespace OpenMEEG {
 
     OPENMEEG_EXPORT Matrix CorticalMat(const Geometry& geo,const SparseMatrix& M,const std::string& domain_name="CORTEX",
                                        const double alpha=-1.0,const double beta=-1.0,const std::string &filename="",
-                                       const Integrator& integrator=Integrator(3,0,0.005));
+                                       const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
 
     OPENMEEG_EXPORT Matrix CorticalMat2(const Geometry& geo,const SparseMatrix& M,const std::string& domain_name="CORTEX",
-                                        const double gamma=1.0,const std::string &filename="",const Integrator& integrator=Integrator(3,0,0.005));
+                                        const double gamma=1.0,const std::string &filename="",const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
 }

--- a/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/include/assemble.h
@@ -36,7 +36,7 @@ namespace OpenMEEG {
 
     OPENMEEG_EXPORT Matrix EITSourceMat(const Geometry& geo,const Sensors& electrodes,const Integrator& integrator=Integrator(3,0,0.005));
 
-    OPENMEEG_EXPORT Matrix Surf2VolMat(const Geometry& geo,const Matrix& points);
+    OPENMEEG_EXPORT Matrix Surf2VolMat(const Geometry& geo,const Matrix& points,const bool verbose=true);
 
     OPENMEEG_EXPORT SparseMatrix Head2EEGMat(const Geometry& geo,const Sensors& electrodes);
     OPENMEEG_EXPORT SparseMatrix Head2ECoGMat(const Geometry& geo,const Sensors& electrodes,const Interface& i);

--- a/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/include/assemble.h
@@ -27,7 +27,7 @@ namespace OpenMEEG {
     // It would be nice to define some constant integrators for the default values but swig does not like them.
 
     OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
-    OPENMEEG_EXPORT Matrix SurfSourceMat(const Geometry& geo,Mesh& sources,const Integrator& integrator=Integrator(3,0,0.005));
+    OPENMEEG_EXPORT Matrix SurfSourceMat(const Geometry& geo,Mesh& sources,const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
 
     OPENMEEG_EXPORT Matrix
     DipSourceMat(const Geometry& geo,const Matrix& dipoles,const Integrator& integrator,const std::string& domain_name);

--- a/OpenMEEG/include/integrator.h
+++ b/OpenMEEG/include/integrator.h
@@ -41,15 +41,18 @@ namespace OpenMEEG {
 
         // TODO: T can be deduced from Function.
 
+        #ifndef SWIGPYTHON  // SWIG sees the integrate def as a syntax error
         template <typename Function>
         decltype(auto) integrate(const Function& function,const Triangle& triangle) const {
             const TrianglePoints tripts = { triangle.vertex(0), triangle.vertex(1), triangle.vertex(2) };
             const auto& coarse = triangle_integration(function,tripts);
             return (max_depth==0) ? coarse : adaptive_integration(function,tripts,coarse,max_depth);
         }
+        #endif /* not SWIGPYTHON */
 
     private:
 
+        #ifndef SWIGPYTHON  // SWIG sees the integrate def as a syntax error
         template <typename Function>
         decltype(auto) triangle_integration(const Function& function,const TrianglePoints& triangle) const {
             using T = decltype(function(Vect3()));
@@ -66,6 +69,7 @@ namespace OpenMEEG {
             const double area2 = crossprod(triangle[1]-triangle[0],triangle[2]-triangle[0]).norm();
             return result*area2;
         }
+        #endif /* not SWIGPYTHON */
 
         template <typename T,typename Function>
         T adaptive_integration(const Function& function,const TrianglePoints& triangle,const T& coarse,const unsigned level) const {

--- a/OpenMEEG/include/integrator.h
+++ b/OpenMEEG/include/integrator.h
@@ -52,7 +52,7 @@ namespace OpenMEEG {
 
     private:
 
-        #ifndef SWIGPYTHON  // SWIG sees the integrate def as a syntax error
+        #ifndef SWIGPYTHON  // SWIG sees the triangle_integration def as a syntax error
         template <typename Function>
         decltype(auto) triangle_integration(const Function& function,const TrianglePoints& triangle) const {
             using T = decltype(function(Vect3()));

--- a/OpenMEEG/include/operators.h
+++ b/OpenMEEG/include/operators.h
@@ -46,7 +46,7 @@ namespace OpenMEEG {
                 const Vertex& A = edge.vertex(0);
                 const Vertex& B = edge.vertex(1);
                 const Vect3& AB = (A-B)/(2*T.area());
-                
+
                 const analyticS analyS(V,A,B);
 
                 result += AB*analyS.f(x);
@@ -163,10 +163,10 @@ namespace OpenMEEG {
 
             const unsigned offset;
         };
-        
+
     public:
 
-        DiagonalBlock(const Mesh& m,const Integrator& intg): base(intg),mesh(m) { }
+        DiagonalBlock(const Mesh& m,const Integrator& intg,const bool verbose=true): base(intg),mesh(m) { this->verbose = verbose; }
 
         template <typename T>
         void set_S_block(const double coeff,T& matrix) {
@@ -286,10 +286,11 @@ namespace OpenMEEG {
     class PartialBlock {
     public:
 
-        PartialBlock(const Mesh& m): mesh(m) { }
+        PartialBlock(const Mesh& m,const bool verbose=true): mesh(m) { this->verbose = verbose; }
 
         void addD(const double coeff,const Vertices& points,Matrix& matrix) const {
-            std::cout << "PARTAL OPERATOR D..." << std::endl;
+            if (verbose)
+                std::cout << "PARTAL OPERATOR D..." << std::endl;
             for (const auto& triangle : mesh.triangles()) {
                 const analyticD3 analyD(triangle);
                 for (const auto& vertex : points) {
@@ -301,7 +302,8 @@ namespace OpenMEEG {
         }
 
         void S(const double coeff,const Vertices& points,Matrix& matrix) const {
-            std::cout << "PARTIAL OPERATOR S..." << std::endl;
+            if (verbose)
+                std::cout << "PARTIAL OPERATOR S..." << std::endl;
             for (const auto& triangle : mesh.triangles()) {
                 const analyticS analyS(triangle);
                 for (const auto& vertex : points)
@@ -309,10 +311,13 @@ namespace OpenMEEG {
             }
         }
 
-
     private:
 
         const Mesh& mesh;
+
+    protected:
+
+        bool verbose = true;
     };
 
     class NonDiagonalBlock: public BlocksBase  {
@@ -335,7 +340,7 @@ namespace OpenMEEG {
             const unsigned i0;
             const unsigned j0;
         };
-        
+
     public:
 
         // This constructor takes the following arguments:
@@ -343,7 +348,7 @@ namespace OpenMEEG {
         //  - The gauss order parameter (for adaptive integration).
         //  - A verbosity parameters (for printing the action on the terminal).
 
-        NonDiagonalBlock(const Mesh& m1,const Mesh& m2,const Integrator& intg): base(intg),mesh1(m1),mesh2(m2) { }
+        NonDiagonalBlock(const Mesh& m1,const Mesh& m2,const Integrator& intg,const bool verbose=true): base(intg),mesh1(m1),mesh2(m2) { this->verbose = verbose; }
 
         template <typename T>
         void set_S_block(const double coeff,T& matrix) {
@@ -379,7 +384,7 @@ namespace OpenMEEG {
 
             // Operator S is given by Sij=\Int G*PSI(I,i)*Psi(J,j) with PSI(l,t) a P0 test function on layer l and triangle t.
 
-            // TODO check the symmetry of S. 
+            // TODO check the symmetry of S.
             // if we invert tit1 with tit2: results in HeadMat differs at 4.e-5 which is too big.
             // using ADAPT_LHS with tolerance at 0.000005 (for S) drops this at 6.e-6 (but increase the computation time).
 
@@ -464,7 +469,7 @@ namespace OpenMEEG {
     template <typename BlockType>
     class HeadMatrixBlocks {
     public:
-        
+
         HeadMatrixBlocks(const BlockType& blk): block(blk) { }
 
         // SymMatrix is initialized at once, and there is nothing to for blockwise matrix.
@@ -489,7 +494,7 @@ namespace OpenMEEG {
                 matrix.add_blocks(trange2,vrange1); // D* blocks when they are not the transpose of D blocks.
         }
         #endif
-        
+
         template <typename T>
         void set_blocks(const double coeffs[3],T& matrix) {
             const double SCondCoeff = coeffs[0];

--- a/OpenMEEG/src/assembleHeadMat.cpp
+++ b/OpenMEEG/src/assembleHeadMat.cpp
@@ -313,7 +313,7 @@ namespace OpenMEEG {
         return (G*H.transpose()*(H*G*H.transpose()).inverse()).submat(0,Nc,Nl,M.nlin());
     }
 
-    Matrix Surf2VolMat(const Geometry& geo,const Matrix& points) {
+    Matrix Surf2VolMat(const Geometry& geo,const Matrix& points,const bool verbose) {
 
         // Find the points per domain and generate the indices for the m_points
         // What happens if a point is on the boundary of a domain ? TODO
@@ -342,7 +342,7 @@ namespace OpenMEEG {
             for (const auto& boundary : domainptr->boundaries())
                 for (const auto& omesh : boundary.interface().oriented_meshes()) {
                     const Mesh& mesh = omesh.mesh();
-                    const PartialBlock block(mesh);
+                    const PartialBlock block(mesh, verbose);
                     const double coeff = boundary.mesh_orientation(omesh)*K;
                     block.addD(-coeff,pts,mat);
                     if (!mesh.current_barrier())

--- a/OpenMEEG/src/assembleHeadMat.cpp
+++ b/OpenMEEG/src/assembleHeadMat.cpp
@@ -120,10 +120,6 @@ namespace OpenMEEG {
     }
     #endif
 
-    SymMatrix HeadMat(const Geometry& geo, const bool verbose) {
-        return HeadMat(geo, Integrator(3,0,0.005), verbose);
-    }
-
     SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator,const bool verbose) {
         return Details::HeadMatrix<SymMatrix>(geo,integrator,Details::AllBlocks(),verbose);
     }

--- a/OpenMEEG/src/assembleHeadMat.cpp
+++ b/OpenMEEG/src/assembleHeadMat.cpp
@@ -178,11 +178,13 @@ namespace OpenMEEG {
 
             P = nullspace_projector(mat);
             if (filename.length()!=0) {
-                std::cout << "Saving projector P (" << filename << ")." << std::endl;
+                if (verbose)
+                    std::cout << "Saving projector P (" << filename << ")." << std::endl;
                 P.save(filename);
             }
         } else {
-            std::cout << "Loading projector P (" << filename << ")." << std::endl;
+            if (verbose)
+                std::cout << "Loading projector P (" << filename << ")." << std::endl;
             P.load(filename);
         }
 
@@ -206,9 +208,11 @@ namespace OpenMEEG {
             alphas.set(0.);
             alpha1 = MM.frobenius_norm()/(1.e3*nRR_v);
             beta1  = alpha1*50000.;
-            std::cout << "AUTOMATIC alphas = " << alpha1 << "\tbeta = " << beta1 << std::endl;
+            if (verbose)
+                std::cout << "AUTOMATIC alphas = " << alpha1 << "\tbeta = " << beta1 << std::endl;
         } else {
-            std::cout << "alphas = " << alpha << "\tbeta = " << beta << std::endl;
+            if (verbose)
+                std::cout << "alphas = " << alpha << "\tbeta = " << beta << std::endl;
         }
 
         for (const auto& vertex : geo.vertices())
@@ -267,11 +271,13 @@ namespace OpenMEEG {
         if (!f) {
             H = HeadMatrix(geo,Cortex,integrator,M.nlin(),verbose);
             if (filename.length()!=0) {
-                std::cout << "Saving matrix H (" << filename << ")." << std::endl;
+                if (verbose)
+                    std::cout << "Saving matrix H (" << filename << ")." << std::endl;
                 H.save(filename);
             }
         } else {
-            std::cout << "Loading matrix H (" << filename << ")." << std::endl;
+            if (verbose)
+                std::cout << "Loading matrix H (" << filename << ")." << std::endl;
             H.load(filename);
         }
 
@@ -300,7 +306,8 @@ namespace OpenMEEG {
                     for (const auto& triangle2 : mesh.triangles())
                         G(triangle1.index(),triangle2.index()) *= gamma;
 
-        std::cout << "gamma = " << gamma << std::endl;
+        if (verbose)
+            std::cout << "gamma = " << gamma << std::endl;
 
         G.invert();
         return (G*H.transpose()*(H*G*H.transpose()).inverse()).submat(0,Nc,Nl,M.nlin());

--- a/OpenMEEG/src/assembleSourceMat.cpp
+++ b/OpenMEEG/src/assembleSourceMat.cpp
@@ -48,7 +48,7 @@ namespace OpenMEEG {
             for (const auto& oriented_mesh : boundary.interface().oriented_meshes()) {
                 const Mesh& mesh = oriented_mesh.mesh();
 
-                NonDiagonalBlock operators(mesh,source_mesh,integrator);
+                NonDiagonalBlock operators(mesh,source_mesh,integrator,verbose);
 
                 // First block is nVertexFistLayer*source_mesh.vertices().size()
                 const double coeffN = factorN*oriented_mesh.orientation();

--- a/OpenMEEG/src/assembleSourceMat.cpp
+++ b/OpenMEEG/src/assembleSourceMat.cpp
@@ -17,7 +17,7 @@
 
 namespace OpenMEEG {
 
-    Matrix SurfSourceMat(const Geometry& geo,Mesh& source_mesh,const Integrator& integrator) {
+    Matrix SurfSourceMat(const Geometry& geo,Mesh& source_mesh,const Integrator& integrator,const bool verbose) {
 
         // Check that there is no overlapping between the geometry and the source mesh.
 
@@ -33,10 +33,11 @@ namespace OpenMEEG {
         source_mesh.outermost()       = true;
         source_mesh.current_barrier() = true;
 
-        std::cout << std::endl
-                  << "assemble SurfSourceMat with " << source_mesh.vertices().size()
-                  << " source_mesh located in domain \"" << domain.name() << "\"." << std::endl
-                  << std::endl;
+        if (verbose)
+            std::cout << std::endl
+                    << "assemble SurfSourceMat with " << source_mesh.vertices().size()
+                    << " source_mesh located in domain \"" << domain.name() << "\"." << std::endl
+                    << std::endl;
 
         Matrix mat(geo.nb_parameters()-geo.nb_current_barrier_triangles(),source_mesh.vertices().size());
         mat.set(0.0);

--- a/wrapping/python/openmeeg/openmeeg.i
+++ b/wrapping/python/openmeeg/openmeeg.i
@@ -66,6 +66,7 @@
     #include <geometry.h>
     #include <GeometryIO.h>
     #include <mesh.h>
+    #include <integrator.h>
     #include <interface.h>
     #include <domain.h>
     #include <assemble.h>
@@ -570,6 +571,7 @@ namespace OpenMEEG {
 %include <GeometryIO.h>
 %include <sensors.h>
 %include <mesh.h>
+// TODO: %include <integrator.h>  Cannot include this because SWIG sees it as a SyntaxError (probably the decltype(auto) ?)
 %include <interface.h>
 %include <domain.h>
 %include <assemble.h>

--- a/wrapping/python/openmeeg/openmeeg.i
+++ b/wrapping/python/openmeeg/openmeeg.i
@@ -571,7 +571,7 @@ namespace OpenMEEG {
 %include <GeometryIO.h>
 %include <sensors.h>
 %include <mesh.h>
-// TODO: %include <integrator.h>  Cannot include this because SWIG sees it as a SyntaxError (probably the decltype(auto) ?)
+%include <integrator.h>
 %include <interface.h>
 %include <domain.h>
 %include <assemble.h>

--- a/wrapping/python/openmeeg/openmeeg.i
+++ b/wrapping/python/openmeeg/openmeeg.i
@@ -571,8 +571,7 @@ namespace OpenMEEG {
 %include <GeometryIO.h>
 %include <sensors.h>
 %include <mesh.h>
-// TODO: Cannot include this because SWIG sees it as a SyntaxError (probably the decltype(auto) ?)
-// %include <integrator.h>
+%include <integrator.h>
 %include <interface.h>
 %include <domain.h>
 %include <assemble.h>

--- a/wrapping/python/openmeeg/openmeeg.i
+++ b/wrapping/python/openmeeg/openmeeg.i
@@ -571,7 +571,8 @@ namespace OpenMEEG {
 %include <GeometryIO.h>
 %include <sensors.h>
 %include <mesh.h>
-%include <integrator.h>
+// TODO: Cannot include this because SWIG sees it as a SyntaxError (probably the decltype(auto) ?)
+// %include <integrator.h>
 %include <interface.h>
 %include <domain.h>
 %include <assemble.h>

--- a/wrapping/python/openmeeg/tests/test_doc.py
+++ b/wrapping/python/openmeeg/tests/test_doc.py
@@ -7,7 +7,8 @@ def test_doc():
     doc = inspect.getdoc(om.HeadMat)
     assert doc is not None
 
-    headmat_expected_docstring = """HeadMat(Geometry geo, \
+    headmat_expected_docstring = """\
+HeadMat(Geometry geo, \
 Integrator integrator=OpenMEEG::Integrator(3,0,0.005), \
 bool const verbose=True) -> SymMatrix"""
     assert (

--- a/wrapping/python/openmeeg/tests/test_doc.py
+++ b/wrapping/python/openmeeg/tests/test_doc.py
@@ -7,7 +7,9 @@ def test_doc():
     doc = inspect.getdoc(om.HeadMat)
     assert doc is not None
 
-    headmat_expected_docstring = """HeadMat(Geometry geo, Integrator const & integrator=Integrator(3,0,0.005), bool const verbose=True) -> SymMatrix
+    headmat_expected_docstring = """HeadMat(Geometry geo, \
+Integrator const & integrator=Integrator(3,0,0.005), \
+bool const verbose=True) -> SymMatrix
 HeadMat(Geometry geo, bool const verbose) -> SymMatrix"""
     assert (
         doc == headmat_expected_docstring

--- a/wrapping/python/openmeeg/tests/test_doc.py
+++ b/wrapping/python/openmeeg/tests/test_doc.py
@@ -7,9 +7,8 @@ def test_doc():
     doc = inspect.getdoc(om.HeadMat)
     assert doc is not None
 
-    headmat_expected_docstring = """\
-HeadMat(Geometry geo, Integrator const & integrator=Integrator(3,0,0.005)) \
--> SymMatrix"""
+    headmat_expected_docstring = """HeadMat(Geometry geo, Integrator const & integrator=Integrator(3,0,0.005), bool const verbose=True) -> SymMatrix
+HeadMat(Geometry geo, bool const verbose) -> SymMatrix"""
     assert (
         doc == headmat_expected_docstring
     ), f"got: {repr(doc)} != expected: {repr(headmat_expected_docstring)}"

--- a/wrapping/python/openmeeg/tests/test_doc.py
+++ b/wrapping/python/openmeeg/tests/test_doc.py
@@ -8,9 +8,8 @@ def test_doc():
     assert doc is not None
 
     headmat_expected_docstring = """HeadMat(Geometry geo, \
-Integrator const & integrator=Integrator(3,0,0.005), \
-bool const verbose=True) -> SymMatrix
-HeadMat(Geometry geo, bool const verbose) -> SymMatrix"""
+Integrator integrator=OpenMEEG::Integrator(3,0,0.005), \
+bool const verbose=True) -> SymMatrix"""
     assert (
         doc == headmat_expected_docstring
     ), f"got: {repr(doc)} != expected: {repr(headmat_expected_docstring)}"

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -53,11 +53,11 @@ def test_python(data_path, tmp_path):
     n_eeg_sensors = patches.getNumberOfSensors()
 
     # Compute forward problem (Build Gain Matrices)
-    # gauss_order = 3  # XXX cannot get Integrator exposed
+    # gauss_order = 3  # XXX cannot get Integrator exposed because of SyntaxError when doing %include <integrator.h>
     # use_adaptive_integration = True
     # dipole_in_cortex = True
 
-    hm = om.HeadMat(geom)
+    hm = om.HeadMat(geom, False)
     hminv = hm.inverse()  # invert hm with a copy
     hminv_inplace = om.HeadMat(geom)
     hminv_inplace.invert()  # invert hm inplace (no copy)

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -57,7 +57,7 @@ def test_python(data_path, tmp_path):
     # use_adaptive_integration = True
     # dipole_in_cortex = True
 
-    hm = om.HeadMat(geom, False)
+    hm = om.HeadMat(geom, om.Integrator(3, 0, 0.005), False)
     hminv = hm.inverse()  # invert hm with a copy
     hminv_inplace = om.HeadMat(geom)
     hminv_inplace.invert()  # invert hm inplace (no copy)

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -60,11 +60,11 @@ def test_python(data_path, tmp_path):
     integrator = om.Integrator(3, 0, 0.005)
     hm = om.HeadMat(geom, integrator, False)
     hminv = hm.inverse()  # invert hm with a copy
-    hminv_inplace = om.HeadMat(geom, om.Integrator(3, 0, 0.005), False)
+    hminv_inplace = om.HeadMat(geom, integrator, False)
     hminv_inplace.invert()  # invert hm inplace (no copy)
     assert_allclose(om.Matrix(hminv).array(), om.Matrix(hminv_inplace).array())
 
-    ssm = om.SurfSourceMat(geom, mesh)
+    ssm = om.SurfSourceMat(geom, mesh, integrator, False)
     ss2mm = om.SurfSource2MEGMat(mesh, sensors)
     dsm = om.DipSourceMat(geom, dipoles, "Brain")
     ds2mm = om.DipSource2MEGMat(dipoles, sensors)

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -57,9 +57,10 @@ def test_python(data_path, tmp_path):
     # use_adaptive_integration = True
     # dipole_in_cortex = True
 
-    hm = om.HeadMat(geom, om.Integrator(3, 0, 0.005), False)
+    integrator = om.Integrator(3, 0, 0.005)
+    hm = om.HeadMat(geom, integrator, False)
     hminv = hm.inverse()  # invert hm with a copy
-    hminv_inplace = om.HeadMat(geom)
+    hminv_inplace = om.HeadMat(geom, om.Integrator(3, 0, 0.005), False)
     hminv_inplace.invert()  # invert hm inplace (no copy)
     assert_allclose(om.Matrix(hminv).array(), om.Matrix(hminv_inplace).array())
 
@@ -112,8 +113,8 @@ def test_python(data_path, tmp_path):
 
     # Leadfield MEG in one line :
     gain_meg_surf_one_line = om.GainMEG(
-        om.HeadMat(geom).inverse(),
-        om.SurfSourceMat(geom, mesh),
+        om.HeadMat(geom, integrator, False).inverse(),
+        om.SurfSourceMat(geom, mesh, integrator, False),
         om.Head2MEGMat(geom, sensors),
         om.SurfSource2MEGMat(mesh, sensors),
     )

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -53,7 +53,7 @@ def test_python(data_path, tmp_path):
     n_eeg_sensors = patches.getNumberOfSensors()
 
     # Compute forward problem (Build Gain Matrices)
-    # gauss_order = 3  # XXX cannot get Integrator exposed
+    # gauss_order = 3  # XXX Integrator is now exposed, just need to use it...
     # use_adaptive_integration = True
     # dipole_in_cortex = True
 

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -53,7 +53,7 @@ def test_python(data_path, tmp_path):
     n_eeg_sensors = patches.getNumberOfSensors()
 
     # Compute forward problem (Build Gain Matrices)
-    # gauss_order = 3  # XXX cannot get Integrator exposed because of SyntaxError when doing %include <integrator.h>
+    # gauss_order = 3  # XXX cannot get Integrator exposed
     # use_adaptive_integration = True
     # dipole_in_cortex = True
 


### PR DESCRIPTION
When running in Python, these outputs so far are mandatory:

https://github.com/mne-tools/mne-python/runs/8145144458?check_suite_focus=true#step:13:602

```
mne/forward/tests/test_make_forward.py::test_make_forward_solution_ctf[testing_data-MNE-C] PASSED [ 15%]
mne/forward/tests/test_make_forward.py::test_make_forward_solution_ctf[testing_data-openmeeg] OPERATOR S ... (arg : mesh Cortex , mesh Cortex )
OPERATOR N ... (arg : mesh Cortex , mesh Cortex )
OPERATOR D ... (arg : mesh Cortex , mesh Cortex )
OPERATOR S ... (arg : mesh Skull , mesh Cortex )
OPERATOR N ... (arg : mesh Skull , mesh Cortex )
OPERATOR D ... (arg : mesh Skull , mesh Cortex )
OPERATOR D*... (arg : mesh Skull , mesh Cortex )
OPERATOR S ... (arg : mesh Skull , mesh Skull )
OPERATOR N ... (arg : mesh Skull , mesh Skull )
OPERATOR D ... (arg : mesh Skull , mesh Skull )
OPERATOR S ... (arg : mesh Head , mesh Skull )
OPERATOR N ... (arg : mesh Head , mesh Skull )
OPERATOR D*... (arg : mesh Head , mesh Skull )
OPERATOR S ... (arg : mesh Head , mesh Head )
OPERATOR N ... (arg : mesh Head , mesh Head )
PASSED [ 15%]
mne/forward/tests/test_make_forward.py::test_make_forward_solution_discrete[testing_data] PASSED [ 15%]
```

This adds a `verbose` argument in the right places so that (I think!) you should be able to do `HeadMat(geo, integrator, False)` in Python to avoid these messages.

It also ~~adds a note about why Integrator can't be exposed. I'll make a clearer note about this in the "python issues" issue.~~ now exposes `om.Integrator` so that it can be passed in.