### PR TITLE
New logging system

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,6 +34,7 @@ jobs:
         key: ${{ github.workflow }}-${{ github.job }}
     - name: Build
       run: |
+        sudo apt -y update
         sudo apt -yq install liblapacke-dev libhdf5-dev libmatio-dev libopenblas-dev python3-numpy
         ./build_tools/cmake_configure.sh
         cmake --build build --config Release

--- a/OpenMEEG/include/NullStream.h
+++ b/OpenMEEG/include/NullStream.h
@@ -1,0 +1,52 @@
+// Project Name: OpenMEEG (http://openmeeg.github.io)
+// © INRIA and ENPC under the French open source license CeCILL-B.
+// See full copyright notice in the file LICENSE.txt
+// If you make a copy of this file, you must either:
+// - provide also LICENSE.txt and modify this header to refer to it.
+// - replace this header by the LICENSE.txt content.
+
+#pragma once
+
+#include <ostream>
+#include <streambuf>
+
+namespace OpenMEEG {
+
+    // Null buffer that store nothing.
+
+    template<typename CharType,typename CharTraits=std::char_traits<CharType>>
+    class NullBuffer: public std::basic_streambuf<CharType,CharTraits> {
+
+        typedef std::basic_streambuf<CharType,CharTraits> base;
+
+	public:
+
+        using typename base::char_type;
+        using typename base::int_type;
+        using typename base::traits_type;
+
+		NullBuffer() : std::streambuf() {}
+
+        virtual std::streamsize
+        xsputn(char_type const*,std::streamsize n) { return n; }
+
+        virtual int_type
+        overflow(int_type c=traits_type::eof()) { return traits_type::not_eof(c); }
+    };
+
+    // Null stream that outputs nothing.
+
+    template<typename CharType,typename CharTraits=std::char_traits<CharType>>
+    class NullStream: public std::basic_ostream<CharType,CharTraits> {
+
+        typedef std::basic_ostream<CharType,CharTraits> base;
+
+	public:
+
+		NullStream(): base(&nullbuf) {}
+
+	private:
+
+		NullBuffer<CharType,CharTraits> nullbuf;
+    };
+}

--- a/OpenMEEG/include/assemble.h
+++ b/OpenMEEG/include/assemble.h
@@ -26,8 +26,8 @@ namespace OpenMEEG {
     // For ADAPT_LHS change the 0 in Integrator below into 10
     // It would be nice to define some constant integrators for the default values but swig does not like them.
 
-    OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
-    OPENMEEG_EXPORT Matrix SurfSourceMat(const Geometry& geo,Mesh& sources,const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
+    OPENMEEG_EXPORT SymMatrix HeadMat(const Geometry& geo,const Integrator& integrator=Integrator(3,0,0.005));
+    OPENMEEG_EXPORT Matrix SurfSourceMat(const Geometry& geo,Mesh& sources,const Integrator& integrator=Integrator(3,0,0.005));
 
     OPENMEEG_EXPORT Matrix
     DipSourceMat(const Geometry& geo,const Matrix& dipoles,const Integrator& integrator,const std::string& domain_name);
@@ -36,7 +36,7 @@ namespace OpenMEEG {
 
     OPENMEEG_EXPORT Matrix EITSourceMat(const Geometry& geo,const Sensors& electrodes,const Integrator& integrator=Integrator(3,0,0.005));
 
-    OPENMEEG_EXPORT Matrix Surf2VolMat(const Geometry& geo,const Matrix& points,const bool verbose=true);
+    OPENMEEG_EXPORT Matrix Surf2VolMat(const Geometry& geo,const Matrix& points);
 
     OPENMEEG_EXPORT SparseMatrix Head2EEGMat(const Geometry& geo,const Sensors& electrodes);
     OPENMEEG_EXPORT SparseMatrix Head2ECoGMat(const Geometry& geo,const Sensors& electrodes,const Interface& i);
@@ -53,8 +53,8 @@ namespace OpenMEEG {
 
     OPENMEEG_EXPORT Matrix CorticalMat(const Geometry& geo,const SparseMatrix& M,const std::string& domain_name="CORTEX",
                                        const double alpha=-1.0,const double beta=-1.0,const std::string &filename="",
-                                       const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
+                                       const Integrator& integrator=Integrator(3,0,0.005));
 
     OPENMEEG_EXPORT Matrix CorticalMat2(const Geometry& geo,const SparseMatrix& M,const std::string& domain_name="CORTEX",
-                                        const double gamma=1.0,const std::string &filename="",const Integrator& integrator=Integrator(3,0,0.005),const bool verbose=true);
+                                        const double gamma=1.0,const std::string &filename="",const Integrator& integrator=Integrator(3,0,0.005));
 }

--- a/OpenMEEG/include/logger.h
+++ b/OpenMEEG/include/logger.h
@@ -1,0 +1,41 @@
+// Project Name: OpenMEEG (http://openmeeg.github.io)
+// © INRIA and ENPC under the French open source license CeCILL-B.
+// See full copyright notice in the file LICENSE.txt
+// If you make a copy of this file, you must either:
+// - provide also LICENSE.txt and modify this header to refer to it.
+// - replace this header by the LICENSE.txt content.
+
+#pragma once
+
+#include <iostream>
+#include <NullStream.h>
+
+namespace OpenMEEG {
+
+    typedef enum { PROGRESS, INFORMATION, WARNING, ERROR, DEBUG } InfoLevel;
+
+    class Logger {
+    public:
+
+        Logger() { }
+
+        void set_info_level(const InfoLevel level) { verbosity = level; }
+
+        bool is_verbose(const InfoLevel level) { return verbosity<=level; }
+
+        static Logger& logger() {
+            static Logger logger;
+            return logger;
+        }
+
+    private:
+
+        InfoLevel verbosity;
+    };
+
+    inline std::ostream&
+    log_stream(const InfoLevel level) {
+        static NullStream<char> nullstream;
+        return (Logger::logger().is_verbose(level)) ? std::cout : nullstream;
+    }
+}

--- a/OpenMEEG/include/om_common.h
+++ b/OpenMEEG/include/om_common.h
@@ -20,9 +20,8 @@ namespace OpenMEEG {
     using Strings = std::vector<std::string>;
 
     // how to compare doubles and floats
-    template<class T>
-    bool almost_equal(T x, T y, double eps = 1e3) {
-        return (std::abs(x-y) < std::numeric_limits<T>::epsilon() * std::abs(x+y) * eps) || std::abs(x-y) < std::numeric_limits<T>::min();
+    template <typename T>
+    bool almost_equal(const T x,const T y,const double eps=1e3) {
+        return (std::abs(x-y)<std::numeric_limits<T>::epsilon()*std::abs(x+y)*eps) || std::abs(x-y)<std::numeric_limits<T>::min();
     }
 }
-

--- a/OpenMEEG/include/operators.h
+++ b/OpenMEEG/include/operators.h
@@ -22,6 +22,7 @@
 #include <integrator.h>
 #include <analytics.h>
 
+#include <logger.h>
 #include <progressbar.h>
 
 namespace OpenMEEG {
@@ -62,13 +63,15 @@ namespace OpenMEEG {
         BlocksBase(const Integrator& intg): integrator(intg) { }
 
         void message(const char* op_name,const Mesh& mesh) const {
-            if (verbose)
-                std::cout << "OPERATOR " << std::left << std::setw(2) << op_name << "... (arg : mesh " << mesh.name() << " )" << std::endl;
+            log_stream(INFORMATION) << std::endl
+                                    << "OPERATOR " << std::left << std::setw(2) << op_name
+                                    << "... (arg : mesh " << mesh.name() << " )" << std::endl;
         }
 
         void message(const char* op_name,const Mesh& mesh1,const Mesh& mesh2) const {
-            if (verbose)
-                std::cout << "OPERATOR " << std::left << std::setw(2) << op_name << "... (arg : mesh " << mesh1.name() << " , mesh " << mesh2.name() << " )" << std::endl;
+            log_stream(INFORMATION) << "OPERATOR " << std::left << std::setw(2) << op_name
+                                    << "... (arg : mesh " << mesh1.name() << " , mesh " << mesh2.name() << " )"
+                                    << std::endl;
         }
 
     protected:
@@ -141,7 +144,6 @@ namespace OpenMEEG {
     protected:
 
         const Integrator integrator;
-        bool             verbose = true;
     };
 
     class DiagonalBlock: public BlocksBase {
@@ -166,7 +168,7 @@ namespace OpenMEEG {
 
     public:
 
-        DiagonalBlock(const Mesh& m,const Integrator& intg,const bool verbose=true): base(intg),mesh(m) { this->verbose = verbose; }
+        DiagonalBlock(const Mesh& m,const Integrator& intg): base(intg),mesh(m) { }
 
         template <typename T>
         void set_S_block(const double coeff,T& matrix) {
@@ -189,7 +191,7 @@ namespace OpenMEEG {
         void set_Dstar_block(const double /* coeff */,T& /* matrix */) const { }
 
         template <typename T>
-        void addId(const double coeff,T& matrix) const {
+        void addIdentity(const double coeff,T& matrix) const {
             // The Matrix is incremented by the identity P1P0 operator
             base::message("Id",mesh);
             for (const auto& triangle : mesh.triangles())
@@ -286,11 +288,10 @@ namespace OpenMEEG {
     class PartialBlock {
     public:
 
-        PartialBlock(const Mesh& m,const bool verbose=true): mesh(m) { this->verbose = verbose; }
+        PartialBlock(const Mesh& m): mesh(m) { }
 
         void addD(const double coeff,const Vertices& points,Matrix& matrix) const {
-            if (verbose)
-                std::cout << "PARTAL OPERATOR D..." << std::endl;
+            log_stream(INFORMATION) << "PARTAL OPERATOR D..." << std::endl;
             for (const auto& triangle : mesh.triangles()) {
                 const analyticD3 analyD(triangle);
                 for (const auto& vertex : points) {
@@ -302,8 +303,7 @@ namespace OpenMEEG {
         }
 
         void S(const double coeff,const Vertices& points,Matrix& matrix) const {
-            if (verbose)
-                std::cout << "PARTIAL OPERATOR S..." << std::endl;
+            log_stream(INFORMATION) << "PARTIAL OPERATOR S..." << std::endl;
             for (const auto& triangle : mesh.triangles()) {
                 const analyticS analyS(triangle);
                 for (const auto& vertex : points)
@@ -314,10 +314,6 @@ namespace OpenMEEG {
     private:
 
         const Mesh& mesh;
-
-    protected:
-
-        bool verbose = true;
     };
 
     class NonDiagonalBlock: public BlocksBase  {
@@ -348,7 +344,7 @@ namespace OpenMEEG {
         //  - The gauss order parameter (for adaptive integration).
         //  - A verbosity parameters (for printing the action on the terminal).
 
-        NonDiagonalBlock(const Mesh& m1,const Mesh& m2,const Integrator& intg,const bool verbose=true): base(intg),mesh1(m1),mesh2(m2) { this->verbose = verbose; }
+        NonDiagonalBlock(const Mesh& m1,const Mesh& m2,const Integrator& intg): base(intg),mesh1(m1),mesh2(m2) { }
 
         template <typename T>
         void set_S_block(const double coeff,T& matrix) {

--- a/OpenMEEG/include/progressbar.h
+++ b/OpenMEEG/include/progressbar.h
@@ -7,8 +7,10 @@
 
 #pragma once
 
+#ifndef USE_PROGRESSBAR
 #include <cmath>
-#include <iostream>
+#include <logger.h>
+#endif
 
 namespace OpenMEEG {
 #ifndef USE_PROGRESSBAR
@@ -20,12 +22,12 @@ namespace OpenMEEG {
         void operator++() {
             const unsigned p = std::min(static_cast<unsigned>(floor(static_cast<double>((bar_size+1)*iter++)/max_iter)),bar_size);
             if (p!=pprev && iter>1) {
-                std::cout << std::string(bar_size+2,'\b') << '[' << std::string(p,'*') << std::string(bar_size-p,'.') << ']';
+                log_stream(PROGRESS) << std::string(bar_size+2,'\b') << '[' << std::string(p,'*') << std::string(bar_size-p,'.') << ']';
                 pprev = p;
             }
             if (iter>=max_iter)
-                std::cout << std::endl;
-            std::cout.flush();
+                log_stream(PROGRESS) << std::endl;
+            log_stream(PROGRESS).flush();
         }
         
     private:

--- a/OpenMEEG/src/assembleSourceMat.cpp
+++ b/OpenMEEG/src/assembleSourceMat.cpp
@@ -17,7 +17,7 @@
 
 namespace OpenMEEG {
 
-    Matrix SurfSourceMat(const Geometry& geo,Mesh& source_mesh,const Integrator& integrator,const bool verbose) {
+    Matrix SurfSourceMat(const Geometry& geo,Mesh& source_mesh,const Integrator& integrator) {
 
         // Check that there is no overlapping between the geometry and the source mesh.
 
@@ -33,11 +33,10 @@ namespace OpenMEEG {
         source_mesh.outermost()       = true;
         source_mesh.current_barrier() = true;
 
-        if (verbose)
-            std::cout << std::endl
-                    << "assemble SurfSourceMat with " << source_mesh.vertices().size()
-                    << " source_mesh located in domain \"" << domain.name() << "\"." << std::endl
-                    << std::endl;
+        log_stream(INFORMATION) << std::endl
+                                << "assemble SurfSourceMat with " << source_mesh.vertices().size()
+                                << " source_mesh located in domain \"" << domain.name() << "\"." << std::endl
+                                << std::endl;
 
         Matrix mat(geo.nb_parameters()-geo.nb_current_barrier_triangles(),source_mesh.vertices().size());
         mat.set(0.0);
@@ -48,7 +47,7 @@ namespace OpenMEEG {
             for (const auto& oriented_mesh : boundary.interface().oriented_meshes()) {
                 const Mesh& mesh = oriented_mesh.mesh();
 
-                NonDiagonalBlock operators(mesh,source_mesh,integrator,verbose);
+                NonDiagonalBlock operators(mesh,source_mesh,integrator);
 
                 // First block is nVertexFistLayer*source_mesh.vertices().size()
                 const double coeffN = factorN*oriented_mesh.orientation();
@@ -129,7 +128,7 @@ namespace OpenMEEG {
                 operators.D(K*orientation,transmat); // D23 or D33 of the formula.
                 if (&mesh1==&mesh2) { // I_33 of the formula, orientation is necessarily 1.
                     DiagonalBlock block(mesh1,integrator);
-                    block.addId(-0.5,transmat);
+                    block.addIdentity(-0.5,transmat);
                 } else { // S_2 of the formula.
                     operators.S(-K*orientation*geo.sigma_inv(mesh1,mesh2),transmat);
                 }

--- a/cmake/Findmatio.cmake
+++ b/cmake/Findmatio.cmake
@@ -1,5 +1,7 @@
 # Find the matio headers and library.
 #
+#  matio_DIR          - the matio directory
+#
 #  matio_INCLUDE_DIRS - where to find matio.h, etc.
 #  matio_LIBRARIES    - List of libraries.
 #  matio_FOUND        - True if matio found.
@@ -13,6 +15,10 @@
 #   We provide a module in case matio has not been found in config mode.
 
 if (NOT matio_LIBRARIES)
+
+    if (NOT matio_DIR AND EXISTS "$ENV{matio_dir}")
+        set(matio_DIR "$ENV{matio_dir}")
+    endif()
 
     if (MATIO_USE_STATIC_LIBRARIES)
         set(HDF5_USE_STATIC_LIBRARIES TRUE)
@@ -42,7 +48,7 @@ if (NOT matio_LIBRARIES)
     endif()
 
     # Look for the header file.
-    find_path(matio_INCLUDE_DIR HINTS $ENV{matio_dir}include NAMES matio.h)
+    find_path(matio_INCLUDE_DIR HINTS ${matio_DIR}/include NAMES matio.h)
 
     message(STATUS "matio.h ${matio_INCLUDE_DIR}")
     mark_as_advanced(matio_INCLUDE_DIR)
@@ -50,12 +56,12 @@ if (NOT matio_LIBRARIES)
     # Look for the library.
 
     # XXXX This needs to go out !
-    set(matio_LIB_SEARCH_PATHS C:/conda/Library/ C:/conda/Library/lib C:/conda/Library/bin $ENV{matio_dir}
-        $ENV{matio_dir}lib $ENV{matio_dir}bin)
+    set(matio_LIB_SEARCH_PATHS C:/conda/Library/ C:/conda/Library/lib C:/conda/Library/bin ${matio_DIR}
+        ${matio_DIR}/lib ${matio_DIR}/bin)
 
     set(MATIO_NAMES matio libmatio)
     if (MATIO_USE_STATIC_LIBRARIES)
-        set(MATIO_NAMES  libmatio.a libmatio-static.lib ${MATIO_NAMES})
+        set(MATIO_NAMES libmatio.a libmatio-static.lib ${MATIO_NAMES})
     endif()
 
     find_library(matio_LIBRARY HINTS ${matio_LIB_SEARCH_PATHS} NAMES ${MATIO_NAMES})

--- a/wrapping/python/openmeeg/__init__.py
+++ b/wrapping/python/openmeeg/__init__.py
@@ -3,4 +3,4 @@ from .openmeeg import *  # noqa
 from ._version import __version__
 from ._make_geometry import make_geometry, make_nested_geometry
 
-Logger.logger().set_info_level(WARNING)
+.openmeeg.Logger.logger().set_info_level(.openmeeg.WARNING)

--- a/wrapping/python/openmeeg/__init__.py
+++ b/wrapping/python/openmeeg/__init__.py
@@ -2,3 +2,5 @@ from . import _distributor_init
 from .openmeeg import *  # noqa
 from ._version import __version__
 from ._make_geometry import make_geometry, make_nested_geometry
+
+Logger.logger().set_info_level(WARNING)

--- a/wrapping/python/openmeeg/__init__.py
+++ b/wrapping/python/openmeeg/__init__.py
@@ -2,5 +2,6 @@ from . import _distributor_init
 from .openmeeg import *  # noqa
 from ._version import __version__
 from ._make_geometry import make_geometry, make_nested_geometry
+from openmeeg import Logger, WARNING
 
-.openmeeg.Logger.logger().set_info_level(.openmeeg.WARNING)
+Logger.logger().set_info_level(WARNING)

--- a/wrapping/python/openmeeg/__init__.py
+++ b/wrapping/python/openmeeg/__init__.py
@@ -3,4 +3,4 @@ from .openmeeg import *  # noqa
 from ._version import __version__
 from ._make_geometry import make_geometry, make_nested_geometry
 
-Logger.logger().set_info_level(WARNING)
+Logger.logger().set_info_level(WARNING)  # noqa

--- a/wrapping/python/openmeeg/__init__.py
+++ b/wrapping/python/openmeeg/__init__.py
@@ -2,6 +2,5 @@ from . import _distributor_init
 from .openmeeg import *  # noqa
 from ._version import __version__
 from ._make_geometry import make_geometry, make_nested_geometry
-from openmeeg import Logger, WARNING
 
 Logger.logger().set_info_level(WARNING)

--- a/wrapping/python/openmeeg/openmeeg.i
+++ b/wrapping/python/openmeeg/openmeeg.i
@@ -52,6 +52,7 @@
 %include <std_vector.i>
 
 %{
+    #include <logger.h>
     #include <vect3.h>
     #include <vertex.h>
     #include <triangle.h>
@@ -152,6 +153,9 @@ namespace OpenMEEG {
 }
 
 namespace OpenMEEG {
+
+    %naturalvar Logger;
+    class Logger;
 
     %naturalvar Mesh;
     class Mesh;
@@ -558,6 +562,7 @@ namespace OpenMEEG {
 
 // Input
 
+%include <logger.h>
 %include <vect3.h>
 %include <vertex.h>
 %include <triangle.h>

--- a/wrapping/python/openmeeg/tests/test_doc.py
+++ b/wrapping/python/openmeeg/tests/test_doc.py
@@ -9,8 +9,7 @@ def test_doc():
 
     headmat_expected_docstring = """\
 HeadMat(Geometry geo, \
-Integrator integrator=OpenMEEG::Integrator(3,0,0.005), \
-bool const verbose=True) -> SymMatrix"""
+Integrator integrator=OpenMEEG::Integrator(3,0,0.005)) -> SymMatrix"""
     assert (
         doc == headmat_expected_docstring
     ), f"got: {repr(doc)} != expected: {repr(headmat_expected_docstring)}"

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -58,13 +58,13 @@ def test_python(data_path, tmp_path):
     # dipole_in_cortex = True
 
     integrator = om.Integrator(3, 0, 0.005)
-    hm = om.HeadMat(geom, integrator, False)
+    hm = om.HeadMat(geom, integrator)
     hminv = hm.inverse()  # invert hm with a copy
-    hminv_inplace = om.HeadMat(geom, integrator, False)
+    hminv_inplace = om.HeadMat(geom, integrator)
     hminv_inplace.invert()  # invert hm inplace (no copy)
     assert_allclose(om.Matrix(hminv).array(), om.Matrix(hminv_inplace).array())
 
-    ssm = om.SurfSourceMat(geom, mesh, integrator, False)
+    ssm = om.SurfSourceMat(geom, mesh, integrator)
     ss2mm = om.SurfSource2MEGMat(mesh, sensors)
     dsm = om.DipSourceMat(geom, dipoles, "Brain")
     ds2mm = om.DipSource2MEGMat(dipoles, sensors)
@@ -113,8 +113,8 @@ def test_python(data_path, tmp_path):
 
     # Leadfield MEG in one line :
     gain_meg_surf_one_line = om.GainMEG(
-        om.HeadMat(geom, integrator, False).inverse(),
-        om.SurfSourceMat(geom, mesh, integrator, False),
+        om.HeadMat(geom, integrator).inverse(),
+        om.SurfSourceMat(geom, mesh, integrator),
         om.Head2MEGMat(geom, sensors),
         om.SurfSource2MEGMat(mesh, sensors),
     )


### PR DESCRIPTION
This adds a new logging system that is better (in my view) than passing a verbose bool on all relevant function. Basically, we have a log_stream(XX) function that provides a logging stream which is decided on the value of XXX to be either std::cout or a null stream. Several logging levels are defined but only two are exploited at this time (INFORMATION and PROGRESS).

The class Logger keeps (with a static member the global state of the logger. For now, I have disabled the logging globally for python (see __init__.py), but it may be meaningful to disable it only for mne....

Compared to the previous solution, it also includes the progressbars.
So far, I kept this only for OpenMEEG (i.e not OpenMEEGMaths).