### PR TITLE
WIP: Python module adjustments

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -483,7 +483,7 @@ jobs:
             export PYTHONPATH=$PWD/install/lib/${PYNAME}${PYVER}/site-packages
           fi
           echo "PYTHONPATH=$PYTHONPATH"
-          python -c "import openmeeg._openmeeg_cxx as _omc; print(_omc.sqr(4)); assert _omc.sqr(4) == 16"
+          python -c "from openmeeg.openmeeg import _Vect3 as Vect3; V = Vect3(1,2,4); print(V); assert V(0) == 1"
         fi
 
     - name: Create, delocate, check, install, and test wheel

--- a/build_tools/cibw_before_build_windows.sh
+++ b/build_tools/cibw_before_build_windows.sh
@@ -26,5 +26,5 @@ python -m pip install "$NUMPY_PIP" --only-binary="numpy"
 cmake -B build -DENABLE_PYTHON=ON -DPython3_EXECUTABLE="$(which python)" .
 cmake --build build --config Release
 python -m pip uninstall -yq numpy
-cp -av build/wrapping/python/openmeeg/*.pyd build/wrapping/python/openmeeg/_openmeeg_cxx.py wrapping/python/openmeeg/
+cp -av build/wrapping/python/openmeeg/*.pyd build/wrapping/python/openmeeg/openmeeg.py wrapping/python/openmeeg/
 rm -Rf build

--- a/wrapping/python/.gitignore
+++ b/wrapping/python/.gitignore
@@ -1,5 +1,5 @@
 *.egg-info
-openmeeg/_openmeeg_cxx.py
+openmeeg/openmeeg.py
 openmeeg/_openmeeg*_wrap.c*
 openmeeg/_*.pyd
 openmeeg/_*.so

--- a/wrapping/python/CMakeLists.txt
+++ b/wrapping/python/CMakeLists.txt
@@ -11,7 +11,6 @@
 # those macros are driven by CMAKE_SWIG_FLAGS, and SWIG_MODULE_XXXXXXX_EXTRA_DEPS
 # where XXXXXXX is the name of the target object in swig_add_library(XXXXXXX ...)
 
-
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
 if (BUILD_TESTING)
     find_package(Pytest)
@@ -28,7 +27,6 @@ include_directories(${Python3_INCLUDE_DIRS}
 )
 
 cmake_policy(SET CMP0078 NEW)
-set(SWIG_TARGET_NAME "openmeeg")
 cmake_policy(SET CMP0086 NEW) # Use NEW policy and explicitly use SWIG_MODULE_NAME
 
 find_package(SWIG REQUIRED)
@@ -37,17 +35,25 @@ find_package(SWIG REQUIRED)
 
 if (SWIG_USE_FILE STREQUAL "")
     message(FATAL_ERROR "unexpected: the variable SWIG_USE_FILE is the empty string. Did you run FindSWIG.cmake?")
-else()
-    include(${SWIG_USE_FILE})
 endif()
+
+include(${SWIG_USE_FILE})
+
+set(SWIG_TARGET_NAME "openmeeg")
 
 list(APPEND CMAKE_SWIG_FLAGS -v -O)
 set(SWIG_MODULE_openmeeg_EXTRA_DEPS openmeeg/numpy.i ${SWIG_MODULE_openmeeg_EXTRA_DEPS})
-set_source_files_properties(openmeeg/_openmeeg.i PROPERTIES CPLUSPLUS ON GENERATED_COMPILE_DEFINITIONS SWIG_PYTHON_SILENT_MEMLEAK SWIG_MODULE_NAME _openmeeg_cxx)
+set_source_files_properties(openmeeg/openmeeg.i PROPERTIES
+    CPLUSPLUS ON
+    GENERATED_COMPILE_DEFINITIONS SWIG_PYTHON_SILENT_MEMLEAK
+    SWIG_MODULE_NAME openmeeg
+)
+
 # This puts _openmeeg.py in openmeeg/
-swig_add_library(${SWIG_TARGET_NAME} LANGUAGE python OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/openmeeg SOURCES openmeeg/_openmeeg.i)
-# This puts __openmeeg.so in openmeeg/
+swig_add_library(${SWIG_TARGET_NAME} LANGUAGE python OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/openmeeg SOURCES openmeeg/openmeeg.i)
+# This puts _openmeeg.so in openmeeg/
 set_target_properties(${SWIG_TARGET_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY openmeeg/)
+
 if (MSVC)
     set_target_properties(${SWIG_TARGET_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_DEBUG openmeeg/)
     set_target_properties(${SWIG_TARGET_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_RELEASE openmeeg/)
@@ -56,8 +62,8 @@ endif()
 if (PYTHON_FORCE_EXT_SUFFIX)
     # For PyPy, see
     # https://github.com/conda-forge/openmeeg-feedstock/pull/20#issuecomment-1161729565
-    if(NOT Python3_EXT_SUFFIX)
-        if(UNIX)
+    if (NOT Python3_EXT_SUFFIX)
+        if (UNIX)
             set(Python3_EXT_SUFFIX ".${Python3_SOABI}.so")
         else()
             set(Python3_EXT_SUFFIX ".${Python3_SOABI}.pyd")
@@ -70,11 +76,10 @@ else()
     message(STATUS "Python default suffix ${Python3_EXT_SUFFIX}")
 endif()
 
-if (APPLE)
-    swig_link_libraries(${SWIG_TARGET_NAME} OpenMEEG::OpenMEEG)
-else()
-    swig_link_libraries(${SWIG_TARGET_NAME} ${Python3_LIBRARIES} OpenMEEG::OpenMEEG)
+if (NOT APPLE)
+    set(SWIG_PYTHON_LIBS ${Python3_LIBRARIES})
 endif()
+swig_link_libraries(${SWIG_TARGET_NAME} ${SWIG_PYTHON_LIBS} OpenMEEG::OpenMEEG)
 
 set(PYTHON_SITE_ARCH ${Python3_SITEARCH})
 if (PYTHON_INSTALL_RELATIVE)
@@ -103,6 +108,7 @@ add_custom_command(
 )
 
 # Installation just copies the directory
+
 install(DIRECTORY  ${OpenMEEG_BINARY_DIR}/wrapping/python/openmeeg
         DESTINATION ${PYTHON_SITE_ARCH}
         DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
@@ -110,23 +116,14 @@ install(DIRECTORY  ${OpenMEEG_BINARY_DIR}/wrapping/python/openmeeg
 if (APPLE)
     set_target_properties(${SWIG_TARGET_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endif()
+
 if (PYTHON_COPY_RUNTIME_DLLS)
     add_custom_command(TARGET ${SWIG_TARGET_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${SWIG_TARGET_NAME}> ${CMAKE_BINARY_DIR}
-        COMMAND_EXPAND_LISTS
-        COMMENT "Python: Copying runtime DLLs for ${SWIG_TARGET_NAME}"
-        VERBATIM
-    )
-    add_custom_command(TARGET ${SWIG_TARGET_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:OpenMEEG> ${CMAKE_BINARY_DIR}
-        COMMAND_EXPAND_LISTS
-        COMMENT "Python: Copying runtime DLLs for OpenMEEG"
-        VERBATIM
-    )
-    add_custom_command(TARGET ${SWIG_TARGET_NAME} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:OpenMEEGMaths> ${CMAKE_BINARY_DIR}
         COMMAND_EXPAND_LISTS
-        COMMENT "Python: Copying runtime DLLs for OpenMEEGMaths"
+        COMMENT "Python: Copying runtime DLLs for ${SWIG_TARGET_NAME}, OpenMEEG and OpenMEEGMaths"
         VERBATIM
     )
 endif()

--- a/wrapping/python/openmeeg/__init__.py
+++ b/wrapping/python/openmeeg/__init__.py
@@ -1,26 +1,6 @@
 from . import _distributor_init
 
-# Here we import as few things as possible to keep our API as limited as
-# possible
-from ._openmeeg_cxx import (
-    HeadMat,
-    Sensors,
-    Integrator,
-    Head2EEGMat,
-    Head2MEGMat,
-    DipSourceMat,
-    DipSource2MEGMat,
-    GainEEG,
-    GainMEG,
-    GainEEGadjoint,
-    GainMEGadjoint,
-    GainEEGMEGadjoint,
-    Forward,
-    SurfSourceMat,
-    SurfSource2MEGMat,
-    Matrix,
-    SymMatrix,
-)
+from .openmeeg import *
 from ._version import __version__
 from ._make_geometry import make_geometry, make_nested_geometry, read_geometry
 from ._utils import get_log_level, set_log_level, use_log_level

--- a/wrapping/python/openmeeg/_make_geometry.py
+++ b/wrapping/python/openmeeg/_make_geometry.py
@@ -2,8 +2,7 @@
 from pathlib import Path
 import numpy as np
 
-
-from ._openmeeg_cxx import Geometry, Domain, SimpleDomain, Interface, OrientedMesh, Mesh
+from .openmeeg import _Geometry, _Domain, _SimpleDomain, _Interface, _OrientedMesh, _Mesh
 
 
 def _mesh_vertices_and_triangles(mesh):
@@ -32,7 +31,7 @@ def make_geometry(meshes, interfaces, domains):
 
     Returns
     -------
-    geometry : isinstance of om.Geometry
+    geometry : isinstance of om._Geometry
         The geometry that can be used in OpenMEEG.
     """
 
@@ -57,7 +56,7 @@ def make_geometry(meshes, interfaces, domains):
     # Normalize mesh inputs to numpy arrays
 
     for name, mesh in meshes.items():
-        if isinstance(mesh, Mesh):
+        if isinstance(mesh, _Mesh):
             meshes[name] = _mesh_vertices_and_triangles(mesh)
         elif isinstance(mesh, (list, tuple)):
             pass
@@ -70,7 +69,7 @@ def make_geometry(meshes, interfaces, domains):
     # First add mesh points
 
     indmaps = dict()
-    geom = Geometry(len(meshes))
+    geom = _Geometry(len(meshes))
     for name, mesh in meshes.items():
         indmaps[name] = geom.add_vertices(mesh[0])
 
@@ -92,7 +91,7 @@ def make_geometry(meshes, interfaces, domains):
                 "non-empty list of interfaces"
             )
 
-        om_domain = Domain(dname)
+        om_domain = _Domain(dname)
         om_domain.set_conductivity(conductivity)
 
         for iname, side in domain_interfaces:
@@ -106,17 +105,17 @@ def make_geometry(meshes, interfaces, domains):
                     f"Interface definition {iname} first argument should be a "
                     "non-empty list of (mesh,orientation)"
                 )
-            if side != SimpleDomain.Inside and side != SimpleDomain.Outside:
+            if side != _SimpleDomain.Inside and side != _SimpleDomain.Outside:
                 raise Exception(
                     f"Domain {dname}: interface {iname} has a wrong side "
                     "direction (In/Out)"
                 )
 
-            om_interface = Interface(iname)
+            om_interface = _Interface(iname)
             for mesh_name, orientation in oriented_meshes:
                 if (
-                    orientation != OrientedMesh.Normal
-                    and orientation != OrientedMesh.Opposite
+                    orientation != _OrientedMesh.Normal
+                    and orientation != _OrientedMesh.Opposite
                 ):
                     raise Exception(
                         f"Wrong description for interface ({iname}), second "
@@ -124,10 +123,10 @@ def make_geometry(meshes, interfaces, domains):
                     )
 
                 mesh = geom.mesh(mesh_name)
-                oriented_mesh = OrientedMesh(mesh, orientation)
+                oriented_mesh = _OrientedMesh(mesh, orientation)
                 om_interface.oriented_meshes().push_back(oriented_mesh)
 
-            om_domain.boundaries().push_back(SimpleDomain(om_interface, side))
+            om_domain.boundaries().push_back(_SimpleDomain(om_interface, side))
         geom.domains().push_back(om_domain)
 
     geom.finalize()
@@ -148,7 +147,7 @@ def make_nested_geometry(meshes, conductivity):
 
     Returns
     -------
-    geometry : isinstance of om.Geometry
+    geometry : isinstance of om._Geometry
         The geometry that can be used in OpenMEEG.
     """
 
@@ -168,32 +167,32 @@ def make_nested_geometry(meshes, conductivity):
 
         # It should be possible to have multiple oriented meshes per interface.
         # e.g.
-        # interface1 = [(m1,om.OrientedMesh.Normal),
-        #               (m2,om.OrientedMesh.Opposite),
-        #               (m3,om.OrientedMesh.Normal)]
+        # interface1 = [(m1,om._OrientedMesh.Normal),
+        #               (m2,om._OrientedMesh.Opposite),
+        #               (m3,om._OrientedMesh.Normal)]
         # It should also be possible to have a name added at the beginning of the
         # tuple.
 
         interfaces = {
-            "Cortex": [("Cortex", OrientedMesh.Normal)],
-            "Skull": [("Skull", OrientedMesh.Normal)],
-            "Head": [("Head", OrientedMesh.Normal)],
+            "Cortex": [("Cortex", _OrientedMesh.Normal)],
+            "Skull": [("Skull", _OrientedMesh.Normal)],
+            "Head": [("Head", _OrientedMesh.Normal)],
         }
 
         domains = {
             "Scalp": (
                 [
-                    ("Skull", SimpleDomain.Outside),
-                    ("Head", SimpleDomain.Inside),
+                    ("Skull", _SimpleDomain.Outside),
+                    ("Head", _SimpleDomain.Inside),
                 ],
                 scalp_conductivity,
             ),
-            "Brain": ([("Cortex", SimpleDomain.Inside)], brain_conductivity),
-            "Air": ([("Head", SimpleDomain.Outside)], 0.0),
+            "Brain": ([("Cortex", _SimpleDomain.Inside)], brain_conductivity),
+            "Air": ([("Head", _SimpleDomain.Outside)], 0.0),
             "Skull": (
                 [
-                    ("Cortex", SimpleDomain.Outside),
-                    ("Skull", SimpleDomain.Inside),
+                    ("Cortex", _SimpleDomain.Outside),
+                    ("Skull", _SimpleDomain.Inside),
                 ],
                 skull_conductivity,
             ),
@@ -206,12 +205,12 @@ def make_nested_geometry(meshes, conductivity):
         (brain_conductivity,) = conductivity
 
         interfaces = {
-            "Cortex": [("Cortex", OrientedMesh.Normal)],
+            "Cortex": [("Cortex", _OrientedMesh.Normal)],
         }
 
         domains = {
-            "Brain": ([("Cortex", SimpleDomain.Inside)], brain_conductivity),
-            "Air": ([("Cortex", SimpleDomain.Outside)], 0.0),
+            "Brain": ([("Cortex", _SimpleDomain.Inside)], brain_conductivity),
+            "Air": ([("Cortex", _SimpleDomain.Outside)], 0.0),
         }
 
     geom = make_geometry(meshes, interfaces, domains)
@@ -230,9 +229,9 @@ def read_geometry(geom_file, cond_file):
 
     Returns
     -------
-    geometry : isinstance of om.Geometry
+    geometry : isinstance of om._Geometry
         The geometry that can be used in OpenMEEG.
     """
     geom_file = str(Path(geom_file).resolve())
     cond_file = str(Path(cond_file).resolve())
-    return Geometry(geom_file, cond_file)
+    return _Geometry(geom_file, cond_file)

--- a/wrapping/python/openmeeg/_utils.py
+++ b/wrapping/python/openmeeg/_utils.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 
-from ._openmeeg_cxx import Logger, ERROR, WARNING, INFORMATION, DEBUG
-
+from .openmeeg import Logger, ERROR, WARNING, INFORMATION, DEBUG
 
 _warn_map = dict(
     error=ERROR,
@@ -9,7 +8,6 @@ _warn_map = dict(
     info=INFORMATION,
     debug=DEBUG,
 )
-
 
 def set_log_level(level):
     """Set the logging level.

--- a/wrapping/python/openmeeg/openmeeg.i
+++ b/wrapping/python/openmeeg/openmeeg.i
@@ -51,6 +51,7 @@
 #endif
 
 %rename("_%s", %$isclass) "";
+%rename("_Matrix_Free") Matrix_Free;
 
 %rename("Logger") Logger;
 

--- a/wrapping/python/openmeeg/openmeeg.i
+++ b/wrapping/python/openmeeg/openmeeg.i
@@ -50,6 +50,31 @@
 #pragma warning(disable:4701)  /* potentially uninitialized local variable 'v' used */
 #endif
 
+%rename("_%s", %$isclass) "";
+
+%rename("Logger") Logger;
+
+%rename("Matrix") Matrix;
+%rename("SymMatrix") SymMatrix;
+
+%rename("Forward") Forward;
+%rename("GainEEG") GainEEG;
+%rename("GainMEG") GainMEG;
+%rename("GainEEGadjoint") GainEEGadjoint;
+%rename("GainMEGadjoint") GainMEGadjoint;
+%rename("GainEEGMEGadjoint") GainEEGMEGadjoint;
+%rename("GainInternalPot") GainInternalPot;
+%rename("GainEITInternalPot") GainEITInternalPot;
+%rename("Integrator") Integrator;
+%rename("Sensors") Sensors;
+
+%ignore crossprod;
+%ignore det;
+%ignore dotprod;
+%ignore log_stream;
+%ignore sizet_to_int;
+%ignore sqr;
+
 %include <std_string.i>
 %include <std_vector.i>
 
@@ -128,17 +153,17 @@
 
 namespace std {
     // std::vector<Mesh> cannot be handled similarly because swig assumes a copy constructor.
-    %template(vector_int) vector<int>;
-    %template(vector_unsigned) vector<unsigned int>;
-    %template(vector_double) vector<double>;
-    %template(vector_vertex) vector<OpenMEEG::Vertex>;
-    %template(vector_pvertex) vector<OpenMEEG::Vertex *>;
-    %template(vector_triangle) vector<OpenMEEG::Triangle>;
-    %template(vector_string) vector<std::string>;
-    %template(vector_interface) vector<OpenMEEG::Interface>;
-    %template(vector_simple_dom) vector<OpenMEEG::SimpleDomain>;
-    %template(vector_domain) vector<OpenMEEG::Domain>;
-    %template(vector_oriented_mesh) vector<OpenMEEG::OrientedMesh>;
+    %template(_vector_int) vector<int>;
+    %template(_vector_unsigned) vector<unsigned int>;
+    %template(_vector_double) vector<double>;
+    %template(_vector_vertex) vector<OpenMEEG::Vertex>;
+    %template(_vector_pvertex) vector<OpenMEEG::Vertex *>;
+    %template(_vector_triangle) vector<OpenMEEG::Triangle>;
+    %template(_vector_string) vector<std::string>;
+    %template(_vector_interface) vector<OpenMEEG::Interface>;
+    %template(_vector_simple_dom) vector<OpenMEEG::SimpleDomain>;
+    %template(_vector_domain) vector<OpenMEEG::Domain>;
+    %template(_vector_oriented_mesh) vector<OpenMEEG::OrientedMesh>;
 }
 
 namespace OpenMEEG {
@@ -198,7 +223,7 @@ namespace OpenMEEG {
 
     // Creator of Vector from PyArrayObject or Vector
 
-    OpenMEEG::Vector* new_OpenMEEG_Vector(PyObject* pyobj) {
+    OpenMEEG::Vector* _new_OpenMEEG_Vector(PyObject* pyobj) {
         if (pyobj && PyArray_Check(pyobj)) {
             PyArrayObject* vect = reinterpret_cast<PyArrayObject*>(PyArray_FromObject(pyobj,NPY_DOUBLE,1,1));
             const size_t nelem = PyArray_DIM(vect,0);
@@ -219,7 +244,7 @@ namespace OpenMEEG {
 
     // Creator of Matrix from PyArrayObject or Matrix
 
-    OpenMEEG::Matrix* new_OpenMEEG_Matrix(PyObject* pyobj) {
+    OpenMEEG::Matrix* _new_OpenMEEG_Matrix(PyObject* pyobj) {
         if (pyobj && PyArray_Check(pyobj)) {
             const int nbdims = PyArray_NDIM(reinterpret_cast<PyArrayObject*>(pyobj));
             if (nbdims!=2)
@@ -247,7 +272,7 @@ namespace OpenMEEG {
         return new Matrix(*(reinterpret_cast<OpenMEEG::Matrix*>(ptr)));
     }
 
-    OpenMEEG::SymMatrix* new_OpenMEEG_SymMatrix(PyObject* pyobj) {
+    OpenMEEG::SymMatrix* _new_OpenMEEG_SymMatrix(PyObject* pyobj) {
         if (pyobj && PyArray_Check(pyobj)) {
             const int nbdims = PyArray_NDIM(reinterpret_cast<PyArrayObject*>(pyobj));
             if (nbdims!=1)
@@ -276,7 +301,7 @@ namespace OpenMEEG {
     }
 
     IndexMap
-    geom_add_vertices(Geometry* geom,PyObject* pyobj) {
+    _geom_add_vertices(Geometry* geom,PyObject* pyobj) {
 
         if (pyobj==nullptr || !PyArray_Check(pyobj))
             throw Error(SWIG_TypeError,"Vertices matrix should be an array.");
@@ -300,7 +325,7 @@ namespace OpenMEEG {
     }
 
     void
-    mesh_add_triangles(Mesh* mesh,PyObject* pyobj,const IndexMap& indmap) {
+    _mesh_add_triangles(Mesh* mesh,PyObject* pyobj,const IndexMap& indmap) {
         if (pyobj==nullptr || !PyArray_Check(pyobj))
             throw Error(SWIG_TypeError,"Matrix of triangles should be an array.");
 
@@ -358,7 +383,7 @@ namespace OpenMEEG {
 
     // Python -> C++
     %typemap(in) Vector& {
-        $1 = new_OpenMEEG_Vector($input);
+        $1 = _new_OpenMEEG_Vector($input);
     }
 
     %typemap(freearg) Vector& {
@@ -366,7 +391,7 @@ namespace OpenMEEG {
     }
 
     %typemap(in) Matrix& {
-        $1 = new_OpenMEEG_Matrix($input);
+        $1 = _new_OpenMEEG_Matrix($input);
     }
 
     %typemap(freearg) Matrix& {
@@ -395,7 +420,7 @@ namespace OpenMEEG {
 
     IndexMap
     add_vertices(PyObject* pyobj) {
-        return geom_add_vertices($self,pyobj);
+        return _geom_add_vertices($self,pyobj);
     }
 }
 
@@ -431,7 +456,7 @@ namespace OpenMEEG {
 }
 
 %extend OpenMEEG::Vector {
-    Vector(PyObject* pyobj) { return new_OpenMEEG_Vector(pyobj); }
+    Vector(PyObject* pyobj) { return _new_OpenMEEG_Vector(pyobj); }
 
     PyObject* array() {
         const npy_intp ndims = 1;
@@ -453,7 +478,7 @@ namespace OpenMEEG {
 
 %extend OpenMEEG::Matrix {
 
-    Matrix(PyObject* pyobj) { return new_OpenMEEG_Matrix(pyobj); }
+    Matrix(PyObject* pyobj) { return _new_OpenMEEG_Matrix(pyobj); }
 
     static void Free(PyObject* capsule) {
         SharedData* shared_data = reinterpret_cast<SharedData*>(PyCapsule_GetPointer(capsule,PyCapsule_GetName(capsule)));
@@ -495,7 +520,7 @@ namespace OpenMEEG {
 }
 
 %extend OpenMEEG::SymMatrix {
-    SymMatrix(PyObject* pyobj) { return new_OpenMEEG_SymMatrix(pyobj); }
+    SymMatrix(PyObject* pyobj) { return _new_OpenMEEG_SymMatrix(pyobj); }
 
     PyObject* array_flat() {
         const npy_intp ndims = 1;
@@ -525,14 +550,14 @@ namespace OpenMEEG {
 %extend OpenMEEG::Mesh {
 
     void add_triangles(PyObject* pyobj,const IndexMap& indmap) {
-        mesh_add_triangles($self,pyobj,indmap);
+        _mesh_add_triangles($self,pyobj,indmap);
     }
 
     Mesh(PyObject* vertices,PyObject* triangles,const std::string name="",Geometry* geom=nullptr) {
         Mesh* mesh = new Mesh(geom);
         mesh->name() = name;
-        const OpenMEEG::IndexMap& indmap = geom_add_vertices(&(mesh->geometry()),vertices);
-        mesh_add_triangles(mesh,triangles,indmap);
+        const OpenMEEG::IndexMap& indmap = _geom_add_vertices(&(mesh->geometry()),vertices);
+        _mesh_add_triangles(mesh,triangles,indmap);
         mesh->update(true);
         return mesh;
     }
@@ -560,7 +585,7 @@ namespace OpenMEEG {
             if (item==nullptr || !PyList_Check(item) || PyList_Size(item)!=3)
                 throw Error(SWIG_TypeError, "Geometry constructor argument must be a list of lists, each of length 3");
             PyObject* vertices = PyList_GetItem(item,1);
-            indmap[i] = geom_add_vertices(geometry,vertices);
+            indmap[i] = _geom_add_vertices(geometry,vertices);
         }
 
         //  Create meshes and add triangles.
@@ -572,7 +597,7 @@ namespace OpenMEEG {
                 throw Error(SWIG_TypeError, "Geometry constructor list of lists must each have first entry a non-empty string.");
             Mesh& mesh = geometry->add_mesh(PyUnicode_AsUTF8(name));
             PyObject* triangles = PyList_GetItem(item,2);
-            mesh_add_triangles(&mesh,triangles,indmap[i]);
+            _mesh_add_triangles(&mesh,triangles,indmap[i]);
             mesh.update(true);
             #ifdef DEBUG
             std::ostringstream oss;

--- a/wrapping/python/openmeeg/tests/test_geometry.py
+++ b/wrapping/python/openmeeg/tests/test_geometry.py
@@ -3,7 +3,8 @@ import numpy as np
 import pytest
 
 import openmeeg as om
-from openmeeg._openmeeg_cxx import Geometry, Mesh
+from openmeeg.openmeeg import _Geometry as Geometry
+from openmeeg.openmeeg import _Mesh as Mesh
 
 
 def test_geometry_private():

--- a/wrapping/python/openmeeg/tests/test_mesh.py
+++ b/wrapping/python/openmeeg/tests/test_mesh.py
@@ -1,11 +1,11 @@
 import os
 import numpy as np
-import openmeeg._openmeeg_cxx as _omc
+from openmeeg.openmeeg import _Mesh as Mesh
 
 
 def check_mesh(name, vertices, triangles, expected_result):
     try:
-        mesh = _omc.Mesh(vertices, triangles)
+        mesh = Mesh(vertices, triangles)
         mesh.info()
     except Exception:
         if expected_result:
@@ -46,7 +46,7 @@ def test_mesh_full(data_path):
     # test X -> should be OK
 
     data_file = os.path.join(data_path, "Head1", "Head1.tri")
-    mesh_X = _omc.Mesh()
+    mesh_X = Mesh()
     mesh_X.load(data_file)
     mesh_X.info()
 
@@ -55,7 +55,7 @@ def test_mesh_full(data_path):
     T_X = mesh_X.triangles()
     assert V_X is not None and T_X is not None
     # V_X.torray() should be possible
-    # mesh_Y = _omc.Mesh(V_X, T_X)  # XXX fails for now
+    # mesh_Y = Mesh(V_X, T_X)  # XXX fails for now
     # mesh_Y.info()
 
     # TODO

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -25,7 +25,9 @@ import shutil
 
 from numpy.testing import assert_allclose
 import openmeeg as om
-import openmeeg._openmeeg_cxx as _omc
+from openmeeg.openmeeg import _Mesh as Mesh
+from openmeeg.openmeeg import _Vertex as Vertex
+from openmeeg.openmeeg import _Vect3 as Vect3
 
 
 def read_geom(geom_file):
@@ -197,7 +199,7 @@ def test_python(subject, data_path, load_from_numpy, tmp_path):
     )
 
     if op.exists(source_mesh_file):
-        mesh = _omc.Mesh(source_mesh_file)
+        mesh = Mesh(source_mesh_file)
         n_dipoles_surf = mesh.vertices().size()
         ssm = om.SurfSourceMat(geom, mesh, integrator)
         gain_eeg_surf = om.GainEEG(hminv, ssm, h2em)
@@ -256,7 +258,7 @@ def test_python(subject, data_path, load_from_numpy, tmp_path):
     # Compute forward data =
 
     src_fname = op.join(data_path, subject, subject + ".srcdip")
-    sources = _omc.Matrix(src_fname)
+    sources = om.Matrix(src_fname)
     n_times = sources.ncol()
 
     noise_level = 0.0
@@ -274,16 +276,16 @@ def test_python(subject, data_path, load_from_numpy, tmp_path):
 
     # Example of basic manipulations
     # TODO: the same with numpy
-    v1 = _omc.Vertex(1.0, 0.0, 0.0, 0)
-    v2 = _omc.Vertex(0.0, 1.0, 0.0, 1)
-    _omc.Vertex(0.0, 0.0, 1.0, 2)
+    v1 = Vertex(1.0, 0.0, 0.0, 0)
+    v2 = Vertex(0.0, 1.0, 0.0, 1)
+    Vertex(0.0, 0.0, 1.0, 2)
     # TODO: v4 = om.Vertex( [double] , int )
 
     # print(v1.norm()
     assert v1.norm() == np.linalg.norm(v1.array())
     assert (v1 + v2).norm() == np.linalg.norm(v1.array() + v2.array())
 
-    normal = _omc.Vect3(1.0, 0.0, 0.0)
+    normal = Vect3(1.0, 0.0, 0.0)
     assert normal.norm() == 1.0
 
     hm_fname = str(tmp_path / f"{subject}.hm")
@@ -324,7 +326,7 @@ def test_pointer_clearing(data_path, tmp_path):
 
     tmp_mesh_path = tmp_path / "Head1.tri"
     assert tmp_mesh_path.is_file()
-    mesh = _omc.Mesh(str(tmp_mesh_path))
+    mesh = Mesh(str(tmp_mesh_path))
     assert mesh.vertices().size() == 42
     os.remove(tmp_mesh_path)
 

--- a/wrapping/python/openmeeg/tests/test_vector.py
+++ b/wrapping/python/openmeeg/tests/test_vector.py
@@ -1,12 +1,12 @@
 import numpy as np
 import pytest
 import openmeeg as om
-import openmeeg._openmeeg_cxx as _omc
+from openmeeg.openmeeg import _Vector as Vector
 
 
 def test_vector():
-    # _omc.Vector -> np.array
-    V1 = _omc.Vector(3)
+    # Vector -> np.array
+    V1 = Vector(3)
     V1.set(2.0)
     print("V1 =", V1, V1.info(), "\n")
 
@@ -14,16 +14,16 @@ def test_vector():
     print("W1 =", W1)
     np.testing.assert_equal(W1, 2 * np.ones(3))
 
-    # np.array -> _omc.Vector
+    # np.array -> Vector
     W2 = np.array([1.0, 2.0, 3.0])
     print("W2 of", W2.__class__)
     print("W2 =", W2, "\n")
 
-    V2 = _omc.Vector(W2, _omc.DEEP_COPY)
+    V2 = Vector(W2, om.DEEP_COPY)
     print("V2 of", V2.__class__)
     V2.info()
 
-    V3 = _omc.Vector(V2)
+    V3 = Vector(V2)
     print("V3 of", V3.__class__)
     V3.info()
 
@@ -34,7 +34,7 @@ def test_vector():
     print("M of", M.__class__)
 
     print("V3 of", V3.__class__)
-    V3 = _omc.Vector(M)
+    V3 = Vector(M)
     print("V3 of", V3.__class__)
     V3.info()
 
@@ -44,7 +44,7 @@ def test_vector():
 
     # degenerate cases
     with pytest.raises(TypeError, match="Input object is neither.*Vector"):
-        _omc.Vector("foo")
-    vec = _omc.Vector(3)
+        Vector("foo")
+    vec = Vector(3)
     with pytest.raises(IndexError, match="Index out of range"):
         vec.value(3)

--- a/wrapping/python/setup.cfg
+++ b/wrapping/python/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 ignore = W503
-exclude = openmeeg/_openmeeg_cxx.py
+exclude = openmeeg/openmeeg.py
 per-file-ignores =
     __init__.py:F401
     setup.py:E501

--- a/wrapping/python/setup.py
+++ b/wrapping/python/setup.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
             "-v",
             "-O",
             "-module",
-            "_openmeeg_cxx",
+            "openmeeg",
             "-interface",
             "_openmeeg",
             "-modern",


### PR DESCRIPTION
OK. This is an alternative approach which I prefer (even though it's not totally without defects).
I tried to control the symbol exported directly at the swig level.

As I did not liked it, I renamed the module openmeeg, but this is maybe to revisit. While I still do not like the name openmeeg_cxx, I finally understood that I was confused by all the various openmeeg names.... openmeeg the package (the directory), openmeeg the module (not sure it is the right name but I mean to refer to the file openmeeg.py), and then openmeeg_so (I do not know how to refer to it).

With these changes, we now get the internal module symbol with sthg like:
`import openmeeg.openmeeg` or
`from openmeeg.openmeeg import _Geometry as Geometry`

The full list of symbols in the module openmeeg is:
```
'CorticalMat'
'CorticalMat2'
'DEBUG'
'DEEP_COPY'
'DipSource2InternalPotMat'
'DipSource2MEGMat'
'DipSourceMat'
'EITSourceMat'
'ERROR'
'Error'
'Forward'
'GainEEG'
'GainEEGMEGadjoint'
'GainEEGadjoint'
'GainEITInternalPot'
'GainInternalPot'
'GainMEG'
'GainMEGadjoint'
'Head2ECoGMat'
'Head2EEGMat'
'Head2MEGMat'
'HeadMat'
'INFORMATION'
'Integrator'
'Logger'
'Logger_logger'
'Matrix'
'Matrix_Free'
'PROGRESS'
'Sensors'
'Surf2VolMat'
'SurfSource2MEGMat'
'SurfSourceMat'
'SymMatrix'
'USE_GMRES'
'WARNING'
'__builtins__'
'__cached__'
'__doc__'
'__file__'
'__loader__'
'__name__'
'__package__'
'__path__'
'__spec__'
'__version__'
'_distributor_init'
'_make_geometry'
'_openmeeg'
'_utils'
'_version'
'get_log_level'
'make_geometry'
'make_nested_geometry'
'openmeeg'
'read_geometry'
'set_log_level'
'use_log_level'
```

The only two that should not be there are Matrix_Free and (probably) USE_GMRES, which is a preprocessor symbol. The last one is easy to correct. For the first one, it is more complicated... The list of "public symbol" is bigger that the one @larsoner exported, but those are necessary as far as I can tell. There is finally, the case of SparseMatrix which is also needed as Matrix and SymMatrix are (this one is also easy to do)...

The nice thing is that all other "private symbols" start with _.
We could even put all/most of the remaining python code directly in the module with
```
%pythoncode %{
%}
```
but I'm not sure I like that.

All tests are passing on my computer, let's see what will say the builders.