### PR TITLE
MAINT: Rename internal _openmeeg_cxx -> _openmeeg_wrapper

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -483,7 +483,7 @@ jobs:
             export PYTHONPATH=$PWD/install/lib/${PYNAME}${PYVER}/site-packages
           fi
           echo "PYTHONPATH=$PYTHONPATH"
-          python -c "import openmeeg._openmeeg_cxx as _omc; print(_omc.sqr(4)); assert _omc.sqr(4) == 16"
+          python -c "import openmeeg._openmeeg_wrapper as _omc; print(_omc.sqr(4)); assert _omc.sqr(4) == 16"
         fi
 
     - name: Create, delocate, check, install, and test wheel

--- a/build_tools/cibw_before_build_windows.sh
+++ b/build_tools/cibw_before_build_windows.sh
@@ -26,5 +26,5 @@ python -m pip install "$NUMPY_PIP" --only-binary="numpy"
 cmake -B build -DENABLE_PYTHON=ON -DPython3_EXECUTABLE="$(which python)" .
 cmake --build build --config Release
 python -m pip uninstall -yq numpy
-cp -av build/wrapping/python/openmeeg/*.pyd build/wrapping/python/openmeeg/_openmeeg_cxx.py wrapping/python/openmeeg/
+cp -av build/wrapping/python/openmeeg/*.pyd build/wrapping/python/openmeeg/_openmeeg_wrapper.py wrapping/python/openmeeg/
 rm -Rf build

--- a/wrapping/python/.gitignore
+++ b/wrapping/python/.gitignore
@@ -1,5 +1,5 @@
 *.egg-info
-openmeeg/_openmeeg_cxx.py
+openmeeg/_openmeeg_wrapper.py
 openmeeg/_openmeeg*_wrap.c*
 openmeeg/_*.pyd
 openmeeg/_*.so

--- a/wrapping/python/CMakeLists.txt
+++ b/wrapping/python/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 
 list(APPEND CMAKE_SWIG_FLAGS -v -O)
 set(SWIG_MODULE_openmeeg_EXTRA_DEPS openmeeg/numpy.i ${SWIG_MODULE_openmeeg_EXTRA_DEPS})
-set_source_files_properties(openmeeg/_openmeeg.i PROPERTIES CPLUSPLUS ON GENERATED_COMPILE_DEFINITIONS SWIG_PYTHON_SILENT_MEMLEAK SWIG_MODULE_NAME _openmeeg_cxx)
+set_source_files_properties(openmeeg/_openmeeg.i PROPERTIES CPLUSPLUS ON GENERATED_COMPILE_DEFINITIONS SWIG_PYTHON_SILENT_MEMLEAK SWIG_MODULE_NAME _openmeeg_wrapper)
 # This puts _openmeeg.py in openmeeg/
 swig_add_library(${SWIG_TARGET_NAME} LANGUAGE python OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/openmeeg SOURCES openmeeg/_openmeeg.i)
 # This puts __openmeeg.so in openmeeg/

--- a/wrapping/python/openmeeg/__init__.py
+++ b/wrapping/python/openmeeg/__init__.py
@@ -2,7 +2,7 @@ from . import _distributor_init
 
 # Here we import as few things as possible to keep our API as limited as
 # possible
-from ._openmeeg_cxx import (
+from ._openmeeg_wrapper import (
     HeadMat,
     Sensors,
     Integrator,

--- a/wrapping/python/openmeeg/_make_geometry.py
+++ b/wrapping/python/openmeeg/_make_geometry.py
@@ -3,7 +3,14 @@ from pathlib import Path
 import numpy as np
 
 
-from ._openmeeg_wrapper import Geometry, Domain, SimpleDomain, Interface, OrientedMesh, Mesh
+from ._openmeeg_wrapper import (
+    Geometry,
+    Domain,
+    SimpleDomain,
+    Interface,
+    OrientedMesh,
+    Mesh,
+)
 
 
 def _mesh_vertices_and_triangles(mesh):

--- a/wrapping/python/openmeeg/_make_geometry.py
+++ b/wrapping/python/openmeeg/_make_geometry.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import numpy as np
 
 
-from ._openmeeg_cxx import Geometry, Domain, SimpleDomain, Interface, OrientedMesh, Mesh
+from ._openmeeg_wrapper import Geometry, Domain, SimpleDomain, Interface, OrientedMesh, Mesh
 
 
 def _mesh_vertices_and_triangles(mesh):

--- a/wrapping/python/openmeeg/_utils.py
+++ b/wrapping/python/openmeeg/_utils.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 
-from ._openmeeg_cxx import Logger, ERROR, WARNING, INFORMATION, DEBUG
+from ._openmeeg_wrapper import Logger, ERROR, WARNING, INFORMATION, DEBUG
 
 
 _warn_map = dict(

--- a/wrapping/python/openmeeg/tests/test_geometry.py
+++ b/wrapping/python/openmeeg/tests/test_geometry.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 import openmeeg as om
-from openmeeg._openmeeg_cxx import Geometry, Mesh
+from openmeeg._openmeeg_wrapper import Geometry, Mesh
 
 
 def test_geometry_private():

--- a/wrapping/python/openmeeg/tests/test_mesh.py
+++ b/wrapping/python/openmeeg/tests/test_mesh.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-import openmeeg._openmeeg_cxx as _omc
+import openmeeg._openmeeg_wrapper as _omc
 
 
 def check_mesh(name, vertices, triangles, expected_result):

--- a/wrapping/python/openmeeg/tests/test_python.py
+++ b/wrapping/python/openmeeg/tests/test_python.py
@@ -25,7 +25,7 @@ import shutil
 
 from numpy.testing import assert_allclose
 import openmeeg as om
-import openmeeg._openmeeg_cxx as _omc
+import openmeeg._openmeeg_wrapper as _omc
 
 
 def read_geom(geom_file):

--- a/wrapping/python/openmeeg/tests/test_vector.py
+++ b/wrapping/python/openmeeg/tests/test_vector.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 import openmeeg as om
-import openmeeg._openmeeg_cxx as _omc
+import openmeeg._openmeeg_wrapper as _omc
 
 
 def test_vector():

--- a/wrapping/python/setup.cfg
+++ b/wrapping/python/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 ignore = W503
-exclude = openmeeg/_openmeeg_cxx.py
+exclude = openmeeg/_openmeeg_wrapper.py
 per-file-ignores =
     __init__.py:F401
     setup.py:E501

--- a/wrapping/python/setup.py
+++ b/wrapping/python/setup.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
             "-v",
             "-O",
             "-module",
-            "_openmeeg_cxx",
+            "_openmeeg_wrapper",
             "-interface",
             "_openmeeg",
             "-modern",


### PR DESCRIPTION
@papadop feel free to merge if you're happy

Then you can rebase #594 or merge `main` into it. But it might actually be easier to start from a new branch to make the related `CMakeFiles.txt` fixes after this is merged.