### PR TITLE
MAINT: Use dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
We should use `dependabot` to avoid things like checkout and setup-python from getting out of date. Will probably need to add a skip for the `cibuildwheel` one that causes an `ELF` error until I can figure that one out.