### PR TITLE
MAINT: Ensure compat with NumPy 2.0 on PyPI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -248,14 +248,14 @@ jobs:
         fi
         if [[ ${{steps.env-vars.outputs.numpy_version}} == 'dev' ]]; then
           echo "Installing NumPy main"
-        	pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0dev0"
+        	pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
         else
           echo "Installing oldest supported NumPy"
           IS_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
           if [[ "$IS_PYPY" == "1" ]]; then
             pip install --upgrade numpy
           else
-            pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0dev0"
+            pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
           fi
         fi
         pip install --upgrade --progress-bar off --only-binary="numpy" -q $NUMPY_PIP setuptools wheel twine "pytest!=8.0.0" threadpoolctl $EXTRA_PIP

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -258,7 +258,7 @@ jobs:
             pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
           fi
         fi
-        pip install --upgrade --progress-bar off --only-binary="numpy" -q $NUMPY_PIP setuptools wheel twine "pytest!=8.0.0" threadpoolctl $EXTRA_PIP
+        pip install --upgrade --progress-bar off --only-binary="numpy" -q $NUMPY_PIP setuptools wheel twine "pytest!=8.0.0,!=8.0.1,!=8.0.2" threadpoolctl $EXTRA_PIP
 
     - name: MKL setup - mkl via conda
       if: startswith(steps.env-vars.outputs.blas,'mkl')

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -258,7 +258,7 @@ jobs:
             pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
           fi
         fi
-        pip install --upgrade --progress-bar off --only-binary="numpy" -q $NUMPY_PIP setuptools wheel twine "pytest!=8.0.0,!=8.0.1,!=8.0.2" threadpoolctl $EXTRA_PIP
+        pip install --upgrade --progress-bar off --only-binary="numpy" -q setuptools wheel twine "pytest!=8.0.0,!=8.0.1,!=8.0.2" threadpoolctl $EXTRA_PIP
 
     - name: MKL setup - mkl via conda
       if: startswith(steps.env-vars.outputs.blas,'mkl')

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -248,14 +248,14 @@ jobs:
         fi
         if [[ ${{steps.env-vars.outputs.numpy_version}} == 'dev' ]]; then
           echo "Installing NumPy main"
-        	pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
+        	pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
         else
           echo "Installing oldest supported NumPy"
           IS_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
           if [[ "$IS_PYPY" == "1" ]]; then
             pip install --upgrade numpy
           else
-            pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
+            pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
           fi
         fi
         pip install --upgrade --progress-bar off --only-binary="numpy" -q $NUMPY_PIP setuptools wheel twine "pytest!=8.0.0" threadpoolctl $EXTRA_PIP

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -248,14 +248,14 @@ jobs:
         fi
         if [[ ${{steps.env-vars.outputs.numpy_version}} == 'dev' ]]; then
           echo "Installing NumPy main"
-        	pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://pypi.anaconda.org/scipy-wheels-nightly/simple" numpy
+        	pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0dev0"
         else
           echo "Installing oldest supported NumPy"
           IS_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
           if [[ "$IS_PYPY" == "1" ]]; then
-            NUMPY_PIP="numpy==1.26.3"
+            pip install --upgrade numpy
           else
-            NUMPY_PIP="oldest-supported-numpy"
+            pip install --upgrade --pre --only-binary ":all:" --default-timeout=60 -i "https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0dev0"
           fi
         fi
         pip install --upgrade --progress-bar off --only-binary="numpy" -q $NUMPY_PIP setuptools wheel twine "pytest!=8.0.0" threadpoolctl $EXTRA_PIP

--- a/.github/workflows/cibuildwheel_apps.yml
+++ b/.github/workflows/cibuildwheel_apps.yml
@@ -67,6 +67,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: "OPENMEEG_MACOS_WHEEL_PURE=false"
           CIBW_ENVIRONMENT_WINDOWS: ""
           CIBW_BUILD: "cp310-*"
+          CIBW_BUILD_FRONTEND: "pip"
           CIBW_BEFORE_ALL: "bash {project}/build_tools/cibw_before_all_apps.sh {project}"
           CIBW_BEFORE_BUILD_WINDOWS: ""
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""

--- a/build_tools/cibw_before_all_apps.sh
+++ b/build_tools/cibw_before_all_apps.sh
@@ -114,7 +114,7 @@ fi
 export PYTHON_OPT="-DENABLE_PYTHON=OFF"
 export BLA_IMPLEMENTATION="OpenBLAS"
 export WERROR_OPT="-DENABLE_WERROR=ON"
-pip install cmake
+pip install cmake numpy  # just need some version of numpy for cibuildwheel to be happy
 export BLA_STATIC_OPT="-DBLA_STATIC=ON"
 ./build_tools/cmake_configure.sh -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX=${ROOT}/install ${LIBDIR_OPT} ${LIBRARIES_INSTALL_OPT} ${PACKAGE_ARCH_OPT} ${CMAKE_OSX_ARCH_OPT} ${CMAKE_PREFIX_PATH_OPT} -DENABLE_APPS=ON ${SHARED_OPT} -DCMAKE_INSTALL_UCRT_LIBRARIES=TRUE ${BLAS_LIBRARIES_OPT} ${LAPACK_LIBRARIES_OPT}
 cmake --build build --config release

--- a/build_tools/cibw_before_all_apps.sh
+++ b/build_tools/cibw_before_all_apps.sh
@@ -114,7 +114,7 @@ fi
 export PYTHON_OPT="-DENABLE_PYTHON=OFF"
 export BLA_IMPLEMENTATION="OpenBLAS"
 export WERROR_OPT="-DENABLE_WERROR=ON"
-pip install cmake numpy  # just need some version of numpy for cibuildwheel to be happy
+pip install cmake
 export BLA_STATIC_OPT="-DBLA_STATIC=ON"
 ./build_tools/cmake_configure.sh -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INSTALL_PREFIX=${ROOT}/install ${LIBDIR_OPT} ${LIBRARIES_INSTALL_OPT} ${PACKAGE_ARCH_OPT} ${CMAKE_OSX_ARCH_OPT} ${CMAKE_PREFIX_PATH_OPT} -DENABLE_APPS=ON ${SHARED_OPT} -DCMAKE_INSTALL_UCRT_LIBRARIES=TRUE ${BLAS_LIBRARIES_OPT} ${LAPACK_LIBRARIES_OPT}
 cmake --build build --config release

--- a/build_tools/cibw_before_build.sh
+++ b/build_tools/cibw_before_build.sh
@@ -11,9 +11,5 @@ cd $ROOT
 pwd
 
 IS_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
-if [[ "$IS_PYPY" == "1" ]]; then
-    python -m pip install numpy --only-binary="numpy"
-else
-    python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
-fi
+python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
 pip install "setuptools>=68.0.0" "wheel>=0.37.0"

--- a/build_tools/cibw_before_build.sh
+++ b/build_tools/cibw_before_build.sh
@@ -14,6 +14,6 @@ IS_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
 if [[ "$IS_PYPY" == "1" ]]; then
     python -m pip install numpy --only-binary="numpy"
 else
-    python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0dev0"
+    python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
 fi
 pip install "setuptools>=68.0.0" "wheel>=0.37.0"

--- a/build_tools/cibw_before_build.sh
+++ b/build_tools/cibw_before_build.sh
@@ -10,21 +10,10 @@ echo "Using project root \"${ROOT}\" on RUNNER_OS=\"${RUNNER_OS}\""
 cd $ROOT
 pwd
 
-# Build the Python bindings on Windows
-ls -al
-rm -Rf build
-cp -a build_nopython build
-which python
-python --version
 IS_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
 if [[ "$IS_PYPY" == "1" ]]; then
     python -m pip install numpy --only-binary="numpy"
 else
     python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0dev0"
 fi
-python -m pip install "setuptools>=68.0.0" "wheel>=0.37.0"
-cmake -B build -DENABLE_PYTHON=ON -DPython3_EXECUTABLE="$(which python)" .
-cmake --build build --config Release
-python -m pip uninstall -yq numpy
-cp -av build/wrapping/python/openmeeg/*.pyd build/wrapping/python/openmeeg/_openmeeg_wrapper.py wrapping/python/openmeeg/
-rm -Rf build
+pip install "setuptools>=68.0.0" "wheel>=0.37.0"

--- a/build_tools/cibw_before_build_windows.sh
+++ b/build_tools/cibw_before_build_windows.sh
@@ -20,6 +20,5 @@ python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="h
 python -m pip install "setuptools>=68.0.0" "wheel>=0.37.0"
 cmake -B build -DENABLE_PYTHON=ON -DPython3_EXECUTABLE="$(which python)" .
 cmake --build build --config Release
-python -m pip uninstall -yq numpy
 cp -av build/wrapping/python/openmeeg/*.pyd build/wrapping/python/openmeeg/_openmeeg_wrapper.py wrapping/python/openmeeg/
 rm -Rf build

--- a/build_tools/cibw_before_build_windows.sh
+++ b/build_tools/cibw_before_build_windows.sh
@@ -20,7 +20,7 @@ IS_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
 if [[ "$IS_PYPY" == "1" ]]; then
     python -m pip install numpy --only-binary="numpy"
 else
-    python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0dev0"
+    python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
 fi
 python -m pip install "setuptools>=68.0.0" "wheel>=0.37.0"
 cmake -B build -DENABLE_PYTHON=ON -DPython3_EXECUTABLE="$(which python)" .

--- a/build_tools/cibw_before_build_windows.sh
+++ b/build_tools/cibw_before_build_windows.sh
@@ -16,12 +16,7 @@ rm -Rf build
 cp -a build_nopython build
 which python
 python --version
-IS_PYPY=$(python -c "import sys; print(int('pypy' in sys.implementation.name))")
-if [[ "$IS_PYPY" == "1" ]]; then
-    python -m pip install numpy --only-binary="numpy"
-else
-    python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
-fi
+python -m pip install --upgrade --pre --only-binary="numpy" --extra-index-url="https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" "numpy>=2.0.0.dev0"
 python -m pip install "setuptools>=68.0.0" "wheel>=0.37.0"
 cmake -B build -DENABLE_PYTHON=ON -DPython3_EXECUTABLE="$(which python)" .
 cmake --build build --config Release

--- a/wrapping/python/openmeeg/_version.py
+++ b/wrapping/python/openmeeg/_version.py
@@ -1,1 +1,1 @@
-__version__ = "2.6.0.dev3"
+__version__ = "2.6.0.dev4"

--- a/wrapping/python/pyproject.toml
+++ b/wrapping/python/pyproject.toml
@@ -4,15 +4,16 @@
 requires = [
     "setuptools>=68.0.0",
     "wheel>=0.37.0",
-    "oldest-supported-numpy; platform_python_implementation!='PyPy'",
-    "numpy==1.26.3; platform_python_implementation=='PyPy'",
+    "numpy<3",
 ]
 
 [tool.cibuildwheel]
 # 3.9 is the only wheel NumPy ships for PyPy as of 2023/01/29
 skip = "cp36-* cp37-* cp38-* *-manylinux_i686 *_ppc64le *_s390x *-musllinux* *-win32 pp37* pp38* pp310* pp*-win_*"
 build-verbosity = "3"
+build-frontend = { name = "pip", args = ["--no-build-isolation"] }
 before-all = "bash {project}/build_tools/cibw_before_all.sh {project}"
+before-build = "bash {project}/build_tools/cibw_before_build.sh {project}"
 # pytest 8.0: https://github.com/pytest-dev/pytest/issues/11884
 test-requires = ["pytest!=8.0.0,!=8.0.1", "threadpoolctl"]
 test-command = "bash {project}/build_tools/cibw_test_command.sh {project}"

--- a/wrapping/python/pyproject.toml
+++ b/wrapping/python/pyproject.toml
@@ -15,7 +15,7 @@ build-frontend = { name = "pip", args = ["--no-build-isolation"] }
 before-all = "bash {project}/build_tools/cibw_before_all.sh {project}"
 before-build = "bash {project}/build_tools/cibw_before_build.sh {project}"
 # pytest 8.0: https://github.com/pytest-dev/pytest/issues/11884
-test-requires = ["pytest!=8.0.0,!=8.0.1", "threadpoolctl"]
+test-requires = ["pytest!=8.0.0,!=8.0.1,!=8.0.2", "threadpoolctl"]
 test-command = "bash {project}/build_tools/cibw_test_command.sh {project}"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
NumPy 2.0 RC is imminent. Let's make sure we have infrastructure to build all against 2.0 and bump the `.dev` version number so a new release shows up on TestPyPI.