### PR TITLE
MAINT: Speed up emulated wheel build

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -45,7 +45,7 @@ jobs:
             arch: x86_64
           - os: macos-14
             arch: arm64
-    timeout-minutes: 60
+    timeout-minutes: 70
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: hendrikmuhs/ccache-action@v1.2
         if: matrix.os != 'ubuntu-latest'
         with:
-          key: ${{ github.job }}-${{ matrix.os }}
+          key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.arch }}
       - name: Cache vcpkg
         if: matrix.os != 'ubuntu-latest'
         uses: actions/cache@v4
@@ -70,7 +70,7 @@ jobs:
           path: |
             vcpkg
             build/vcpkg_installed
-          key: ${{ github.job }}-${{ hashFiles('**/vcpkg.json') }}-${{ matrix.os }}-0
+          key: ${{ github.job }}-${{ hashFiles('**/vcpkg.json') }}-${{ matrix.os }}-${{ matrix.arch }}-0
       - uses: pypa/cibuildwheel@v2.18.1
         with:
           package-dir: ./wrapping/python
@@ -79,7 +79,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   upload_test_pypi:

--- a/build_tools/cibw_before_build_windows.sh
+++ b/build_tools/cibw_before_build_windows.sh
@@ -16,7 +16,7 @@ rm -Rf build
 cp -a build_nopython build
 which python
 python --version
-python -m pip install --upgrade --only-binary="numpy" "numpy>=2.0.0rc1,<3" "setuptools>=68.0.0" "setuptools_scm>=6.2" "wheel>=0.37.0"
+python -m pip install --upgrade --only-binary="numpy" "numpy>=2.0.0rc2,<3" "setuptools>=68.0.0" "setuptools_scm>=6.2" "wheel>=0.37.0"
 cmake -B build -DENABLE_PYTHON=ON -DPython3_EXECUTABLE="$(which python)" .
 cmake --build build --config Release
 cp -av build/wrapping/python/openmeeg/*.pyd build/wrapping/python/openmeeg/_openmeeg_wrapper.py wrapping/python/openmeeg/

--- a/wrapping/python/pyproject.toml
+++ b/wrapping/python/pyproject.toml
@@ -63,10 +63,11 @@ local_scheme = "no-local-version"  # to allow TestPyPI uploads
 
 [tool.cibuildwheel]
 # 3.9 is the only wheel NumPy ships for PyPy (and not on ARM64) as of 2024/05/20
-skip = ["pp310*", "pp*-win_*", "*-musllinux*", "pp*-macosx_arm64"]
+skip = ["pp310*", "pp*-win_*", "*-musllinux*", "pp*-macosx_arm64", "pp*-manylinux_aarch64"]
 archs = "native"
 build-verbosity = 3
 before-all = "bash {project}/build_tools/cibw_before_all.sh {project}"
+before-build = "pip install --only-binary=numpy \"numpy>=2.0.0rc1,<3\""  # we don't want to build for any platform that NumPy does not provide wheels for
 # pytest 8.0: https://github.com/pytest-dev/pytest/issues/11884
 test-requires = [
     "pytest!=8.0.0,!=8.0.1,!=8.0.2,!=8.1.1,!=8.1.2,!=8.2.0,!=8.2.1;platform_system=='Windows'",


### PR DESCRIPTION
NumPy doesn't provide pp39 aarch64 wheels, let's avoid it. And let's add a `before-build` that makes sure we only build on platforms that have an associated NumPy binary wheel.