### PR TITLE
MAINT: Dont use continue-on-error

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,9 +23,9 @@ defaults:
 jobs:
 
   build:
-    continue-on-error: true
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         # By default, all builds use:
         # - OpenBLAS

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -29,9 +29,9 @@ env:
 # https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions
 jobs:
   build_wheels:
-    continue-on-error: true
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         # macos-13 is an intel runner, macos-14 is apple silicon
         include:

--- a/.github/workflows/cibuildwheel_apps.yml
+++ b/.github/workflows/cibuildwheel_apps.yml
@@ -22,7 +22,6 @@ env:
 # https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions
 jobs:
   apps:
-    continue-on-error: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
`continue-on-error: true` can lead to "successful" builds that had a failing step when `if: always()` is used, so just avoid it. Achieve the desired effect of not killing other *jobs* early with `fail-fast: false` instead.