### PR TITLE
BUG: Work around SWIG segfault on import with warnings-as-error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.14)
-project (OpenMEEG VERSION 2.5.13 LANGUAGES C CXX)
+project (OpenMEEG VERSION 2.5.14 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)  # use c++17
 

--- a/build_tools/cibw_before_build_windows.sh
+++ b/build_tools/cibw_before_build_windows.sh
@@ -16,7 +16,7 @@ rm -Rf build
 cp -a build_nopython build
 which python
 python --version
-python -m pip install --upgrade --only-binary="numpy" "numpy>=2.0.0rc2,<3" "setuptools>=68.0.0" "setuptools_scm>=6.2" "wheel>=0.37.0"
+python -m pip install --upgrade --only-binary="numpy" "numpy>=2.0.0rc2,<3" "setuptools>=68.0.0" "setuptools_scm>=6.2" "wheel>=0.37.0" "swig>=4.2"
 cmake -B build -DENABLE_PYTHON=ON -DPython3_EXECUTABLE="$(which python)" .
 cmake --build build --config Release
 cp -av build/wrapping/python/openmeeg/*.pyd build/wrapping/python/openmeeg/_openmeeg_wrapper.py wrapping/python/openmeeg/

--- a/build_tools/cibw_test_command.sh
+++ b/build_tools/cibw_test_command.sh
@@ -16,3 +16,6 @@ echo ""
 pytest --fixtures $TEST_PATH
 echo ""
 pytest --tb=short -ra -m "not slow" -vv "$TEST_PATH"
+echo ""
+# Smoke test for https://github.com/swig/swig/issues/3061
+PYTHONFAULTHANDLER=1 PYTHONWARNINGS=error python -uc "import openmeeg"

--- a/build_tools/cmake_configure.sh
+++ b/build_tools/cmake_configure.sh
@@ -16,7 +16,7 @@ if [[ "${DISABLE_CCACHE}" != "1" ]]; then
     C_COMPILER_LAUNCHER_OPT="-DCMAKE_C_COMPILER_LAUNCHER=ccache"
 fi
 
-echo "::group:cmake configure"
+echo "::group::cmake configure"
 set -x
 cmake -B build \
       -DCMAKE_BUILD_TYPE=$BUILD_TYPE \

--- a/wrapping/python/openmeeg/__init__.py
+++ b/wrapping/python/openmeeg/__init__.py
@@ -1,6 +1,14 @@
 from importlib.metadata import version as _version
+import warnings as _warnings
 
 from . import _distributor_init
+
+# https://github.com/swig/swig/issues/2881
+with _warnings.catch_warnings():
+    _warnings.simplefilter("ignore")
+    from ._openmeeg_wrapper import HeadMat  # noqa
+    del HeadMat
+
 
 # Here we import as few things as possible to keep our API as limited as
 # possible
@@ -32,4 +40,7 @@ except Exception:
     __version__ = "0.0.0"
 del _version
 
-set_log_level("warning")
+# https://github.com/swig/swig/issues/2881
+with _warnings.catch_warnings():
+    _warnings.simplefilter("ignore")
+    set_log_level("warning")

--- a/wrapping/python/pyproject.toml
+++ b/wrapping/python/pyproject.toml
@@ -50,13 +50,13 @@ requires = [
     "swig>=4.2",
 ]
 
-[tool.setuptools]
-zip-safe = false
-include-package-data = true  # the default but let's be explicit
-
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["openmeeg*"]
+
+# Keep generated .cpp file for informational and debugging purposes
+[tool.setuptools.package-data]
+openmeeg = ["*.pyi", "*.cpp"]
 
 [tool.setuptools_scm]
 root = "../../"

--- a/wrapping/python/setup.py
+++ b/wrapping/python/setup.py
@@ -111,7 +111,9 @@ if __name__ == "__main__":
         define_macros = [("SWIG_PYTHON_SILENT_MEMLEAK", None)]
         abi3_kwargs = dict()
         if abi3:
-            define_macros += [("Py_LIMITED_API", "0x030A0000")]  # 3.10
+            define_macros += [
+                ("Py_LIMITED_API", "0x030A0000"),  # 3.10
+            ]
         swig_openmeeg = Extension(
             "openmeeg._openmeeg",
             sources=["openmeeg/_openmeeg.i"],


### PR DESCRIPTION
:crossed_fingers: that this works, in which case I'll quickly cut a 2.5.14. Fortunately there probably aren't many end-users using warnings-as-errors, but it's a problem for MNE-Python for example (which does so in its test suite).