### PR TITLE
Tidy up python detection since we require a cmake version > 3.12.

### DIFF
--- a/cmake/FindPytest.cmake
+++ b/cmake/FindPytest.cmake
@@ -1,12 +1,7 @@
 # Adapted from FindNumpy.cmake (MIT)
+# Assumes a python interpreter has already been found.
 
-if (Pytest_FIND_REQUIRED)
-    find_package(PythonInterp REQUIRED)
-else()
-    find_package(PythonInterp)
-endif()
-
-if (NOT PYTHONINTERP_FOUND)
+if (NOT Python3::Interpreter)
     set(PYTEST_FOUND FALSE)
     return()
 endif()

--- a/wrapping/python/CMakeLists.txt
+++ b/wrapping/python/CMakeLists.txt
@@ -11,9 +11,12 @@
 # those macros are driven by CMAKE_SWIG_FLAGS, and SWIG_MODULE_XXXXXXX_EXTRA_DEPS
 # where XXXXXXX is the name of the target object in swig_add_library(XXXXXXX ...)
 
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
+    cmake_policy(SET CMP0148 NEW)  # fail FindPythonInterp / FindPythonLibs
+endif()
 
-cmake_policy(SET CMP0148 NEW)  # fail FindPythonInterp / FindPythonLibs
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development NumPy)
+
 if (BUILD_TESTING)
     find_package(Pytest)
 endif()


### PR DESCRIPTION
Remove a use of FindPythonInterp.