### PR TITLE
Remove mingw remnants

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -583,9 +583,10 @@ jobs:
           test -f "$FNAME"
           mv "$ORIG_FNAME" "${ORIG_FNAME}.whl"
           delocate-listdeps --all "$FNAME"
-        else
-          auditwheel show "$FNAME"
-          auditwheel repair "$FNAME"
+        # This build uses a toolchain that is too new, so skip this on Linux
+        # else
+        #   auditwheel show "$FNAME"
+        #   auditwheel repair "$FNAME"
         fi
         rm -Rf check
         unzip "$FNAME" -d check

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,7 +61,6 @@ jobs:
           blas: OpenBLAS
           blas_linking: dynamic
           python: cmake
-          windows_compiler: msvc
           testing: fast
         - os: macos-latest
           blas: OpenBLAS
@@ -93,14 +92,6 @@ jobs:
           numpy: numpydev
           testing: thorough
           python-version: '3.13'
-        # Windows mingw64 is disabled because of some path problem where cmake
-        # cannot find Python3 (!). We don't really need it because wheels and
-        # conda-forge both use MSVC, things work there, and it's the official
-        # Windows compiler. So we disable it for now at least (YAGNI).
-        # There is some stuff below and in cmake_configure.sh we could get rid
-        # of if we decide to fully drop it later.
-        # - os: windows-latest
-        #   windows_compiler: mingw64
         # MKL on Linux and Windows (static unless it has to be dynamic)
         - os: windows-latest
           blas: mkl-findblas
@@ -170,11 +161,6 @@ jobs:
             echo "Unknown matrix.python=\"${{matrix.python}}\""
             exit 1
           fi
-        fi
-        if [[ "${{matrix.windows_compiler}}" == "mingw64" ]]; then
-          echo "windows_compiler=mingw64" | tee -a $GITHUB_OUTPUT
-        else
-          echo "windows_compiler=msvc" | tee -a $GITHUB_OUTPUT
         fi
         if [[ "${{matrix.testing}}" == "thorough" ]]; then
           SLOW_OPT="-DTEST_SLOW_PYTHON=ON"
@@ -322,18 +308,14 @@ jobs:
         path: |
           vcpkg
           build/vcpkg_installed
-        key: vcpkg-${{ hashFiles('**/vcpkg.json', '**/vcpkg_version.txt') }}-${{ steps.env-vars.outputs.windows_compiler }}-0
+        key: vcpkg-${{ hashFiles('**/vcpkg.json', '**/vcpkg_version.txt') }}
 
     - name: Windows 2 - hdf5 and libmatio via vcpkg
       if: startsWith(steps.env-vars.outputs.os,'windows')
       id: runvcpkg
       run: |
-        if [[ "${{ steps.env-vars.outputs.windows_compiler }}" == "mingw64" ]]; then
-          export VCPKG_DEFAULT_TRIPLET="x64-mingw-dynamic"
-        else
-          export VCPKG_DEFAULT_TRIPLET="x64-windows-release"
-          export CMAKE_GENERATOR="Visual Studio 17 2022"
-        fi
+        export VCPKG_DEFAULT_TRIPLET="x64-windows-release"
+        export CMAKE_GENERATOR="Visual Studio 17 2022"
         source ./build_tools/setup_vcpkg_compilation.sh
         # On Windows, we tell cmake to copy all runtime deps to the build dir,
         # and for tests (and Python) to find them, we need to add it to PATH
@@ -467,9 +449,6 @@ jobs:
         ls -al *.dll || true
         if [[ "${{steps.env-vars.outputs.blas}}" == "OpenBLAS" ]]; then
           #if [[ "${{ steps.env-vars.outputs.blas_linking }}" != "static" ]]; then
-          if [[ "{{ steps.env-vars.outputs.windows_compiler }}" != "msvc"* ]]; then
-            strip $OPENBLAS_LIB/libopenblas*.dll
-          fi
           cp -v $OPENBLAS_LIB/libopenblas*.dll .
           cp -v $OPENBLAS_LIB/libopenblas*.dll openblas.dll
           #fi
@@ -478,14 +457,6 @@ jobs:
           ls -alR $(cygpath -u $CONDA_PREFIX)/Library/bin
           cp -v $(cygpath -u $CONDA_PREFIX)/Library/bin/*mkl*.dll .
           echo "DELVEWHEEL_ADD_DLL=--add-dll=mkl_intel_thread.2.dll" | tee -a $GITHUB_ENV
-        fi
-        if [[ "{{ steps.env-vars.outputs.windows_compiler }}" != "msvc"* ]]; then
-          cp /c/Strawberry/c/bin/libquadmath-0.dll .
-          cp -v /mingw64/bin/libgcc_s_seh-1.dll .
-          cp -v /mingw64/bin/libwinpthread-1.dll .
-          cp -v /mingw64/bin/libstdc++-6.dll .
-          strip libstdc++-6.dll
-          cp -v /c/Strawberry/c/bin/libgomp-1.dll .
         fi
         if [[ -f "./OpenMEEGMaths/libmatio.dll" ]]; then
           cp -v ./OpenMEEGMaths/libmatio.dll .
@@ -561,9 +532,7 @@ jobs:
             export PATH="$PWD/build:$PWD/install/bin:$(cygpath -u $CONDA_PREFIX)/Library:$(cygpath -u $CONDA_PREFIX)/Library/lib:$PATH"
             export OPENMEEG_LIB=$(cygpath -w $OPENMEEG_LIB)
             export OPENMEEG_INCLUDE=$(cygpath -w $OPENMEEG_INCLUDE)
-            if [[ "${{steps.env-vars.outputs.windows_compiler}}" == 'msvc'* ]]; then
-              export CL="/std:c++17"
-            fi
+            export CL="/std:c++17"
             export SWIG_FLAGS="msvc"
             echo "PATH=$PATH"
             echo "CL=$CL"
@@ -616,12 +585,9 @@ jobs:
           test -f "$FNAME"
           mv "$ORIG_FNAME" "${ORIG_FNAME}.whl"
           delocate-listdeps --all "$FNAME"
-        # This build uses a toolchain that is too new, so skip this on Linux
-        # else
-        #   auditwheel show "$FNAME"
-        #   auditwheel repair "$FNAME"
-        #   FNAME=$(ls dist/*.whl)
-        #   test -f "$FNAME"
+        else
+          auditwheel show "$FNAME"
+          auditwheel repair "$FNAME"
         fi
         rm -Rf check
         unzip "$FNAME" -d check
@@ -645,7 +611,7 @@ jobs:
       if: startswith(steps.env-vars.outputs.python, 'python') && (success() || failure())
       uses: actions/upload-artifact@v7
       with:
-        name: wrapping_${{ steps.env-vars.outputs.os }}_${{ steps.env-vars.outputs.python_type }}_${{ steps.env-vars.outputs.blas }}_${{ steps.env-vars.outputs.blas_linking }}_${{ steps.env-vars.outputs.windows_compiler }}_${{ steps.env-vars.outputs.python_version }}_${{ steps.env-vars.outputs.numpy_version }}
+        name: wrapping_${{ steps.env-vars.outputs.os }}_${{ steps.env-vars.outputs.python_type }}_${{ steps.env-vars.outputs.blas }}_${{ steps.env-vars.outputs.blas_linking }}_${{ steps.env-vars.outputs.python_version }}_${{ steps.env-vars.outputs.numpy_version }}
         path: ${{ steps.wheel.outputs.path }}
 
     - name: Test

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -314,8 +314,6 @@ jobs:
       if: startsWith(steps.env-vars.outputs.os,'windows')
       id: runvcpkg
       run: |
-        export VCPKG_DEFAULT_TRIPLET="x64-windows-release"
-        export CMAKE_GENERATOR="Visual Studio 17 2022"
         source ./build_tools/setup_vcpkg_compilation.sh
         # On Windows, we tell cmake to copy all runtime deps to the build dir,
         # and for tests (and Python) to find them, we need to add it to PATH

--- a/build_tools/cibw_before_all.sh
+++ b/build_tools/cibw_before_all.sh
@@ -133,7 +133,6 @@ elif [[ "$PLATFORM" == 'Darwin-'* ]]; then
     LIB_OUTPUT_DIR="$ROOT/install/lib"
 elif [[ "$PLATFORM" == "Windows-AMD64" ]]; then
     export VCPKG_DEFAULT_TRIPLET="x64-windows-release-static"
-    export CMAKE_GENERATOR="Visual Studio 17 2022"
     source ./build_tools/setup_vcpkg_compilation.sh
     pip install delvewheel "pefile!=2024.8.26"
     export SYSTEM_VERSION_OPT="-DCMAKE_SYSTEM_VERSION=7"

--- a/build_tools/setup_vcpkg_compilation.sh
+++ b/build_tools/setup_vcpkg_compilation.sh
@@ -7,7 +7,7 @@ cd $DIR/..
 echo "::group::setup_vcpkg_compilation"
 
 if [[ "$VCPKG_DEFAULT_TRIPLET" == "" ]]; then
-    export VCPKG_DEFAULT_TRIPLET="x64-windows"
+    export VCPKG_DEFAULT_TRIPLET="x64-windows-release"
 fi
 
 USE_CYPATH=1

--- a/build_tools/setup_vcpkg_compilation.sh
+++ b/build_tools/setup_vcpkg_compilation.sh
@@ -11,10 +11,7 @@ if [[ "$VCPKG_DEFAULT_TRIPLET" == "" ]]; then
 fi
 
 USE_CYPATH=1
-if [[ "$VCPKG_DEFAULT_TRIPLET" == 'x64-mingw'* ]]; then
-    export CMAKE_GENERATOR="MinGW Makefiles"
-    export LINKER_OPT="-s"
-elif [[ "$VCPKG_DEFAULT_TRIPLET" == 'x64-windows'* ]]; then
+if [[ "$VCPKG_DEFAULT_TRIPLET" == 'x64-windows'* ]]; then
     if [[ "$CMAKE_GENERATOR" == "" ]]; then  # assume we're using an old version
         CMAKE_GENERATOR="Visual Studio 17 2022"
     fi
@@ -57,9 +54,7 @@ cp -v ./build_tools/vcpkg_triplets/*.cmake vcpkg/triplets
 export VCPKG_INSTALLED_DIR="${PWD}/build/vcpkg_installed"
 export VCPKG_INSTALL_OPTIONS="--x-install-root=$VCPKG_INSTALLED_DIR --triplet=$VCPKG_DEFAULT_TRIPLET"
 export CMAKE_TOOLCHAIN_FILE="${PWD}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-if [[ "$VCPKG_DEFAULT_TRIPLET" != 'x64-mingw'* ]]; then  # for some reason this breaks things
-    export VCPKG_TRIPLET_OPT="-DVCPKG_TARGET_TRIPLET=${VCPKG_DEFAULT_TRIPLET}"
-fi
+export VCPKG_TRIPLET_OPT="-DVCPKG_TARGET_TRIPLET=${VCPKG_DEFAULT_TRIPLET}"
 
 if [[ "$USE_CYGPATH" == "1" ]]; then
     export VCPKG_INSTALLED_DIR=$(cygpath -m "${VCPKG_INSTALLED_DIR}")


### PR DESCRIPTION
We don't test `mingw` compilation in CIs. I don't think it's worth keeping the related dead code around. Can always go back in `git` history to find it if needed, but I'd assume YAGNI.