### PR TITLE
Fix dtype and contiguous bugs in Python wrappers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.21
     hooks:
-      - id: ruff
+      - id: ruff-check
         name: ruff lint
         args: ["--fix", "--config=wrapping/python/pyproject.toml"]
       - id: ruff-format

--- a/wrapping/python/openmeeg/_openmeeg.i
+++ b/wrapping/python/openmeeg/_openmeeg.i
@@ -202,7 +202,16 @@ namespace OpenMEEG {
 
     OpenMEEG::Vector* new_OpenMEEG_Vector(PyObject* pyobj) {
         if (pyobj && PyArray_Check(pyobj)) {
-            PyArrayObject* vect = reinterpret_cast<PyArrayObject*>(PyArray_FromObject(pyobj,NPY_DOUBLE,1,1));
+            // Force a native-byte-order, contiguous double array: the
+            // Vector below references the raw buffer directly (no
+            // element-wise copy), so a non-contiguous input (e.g. a
+            // strided slice) would otherwise be silently misread.
+            PyArrayObject* vect = reinterpret_cast<PyArrayObject*>(
+                PyArray_FROM_OTF(pyobj,NPY_DOUBLE,NPY_ARRAY_IN_ARRAY));
+            if (vect==nullptr)
+                throw Error(SWIG_ValueError,"Vector cannot be converted into an array of double.");
+            if (PyArray_NDIM(vect)!=1)
+                throw Error(SWIG_ValueError,"Vector must be a 1 dimensional array.");
             const size_t nelem = PyArray_DIM(vect,0);
             OpenMEEG::Vector* v = new Vector(nelem);
             v->reference_data(static_cast<double*>(PyArray_GETPTR1(vect,0)));
@@ -228,6 +237,8 @@ namespace OpenMEEG {
                 throw Error(SWIG_TypeError, "Matrix can only have 2 dimensions.");
 
             PyArrayObject* mat = reinterpret_cast<PyArrayObject*>(PyArray_FromObject(pyobj,NPY_DOUBLE,2,2));
+            if (mat==nullptr)
+                throw Error(SWIG_ValueError,"Matrix cannot be converted into an array of double.");
 
             if (!PyArray_ISFARRAY(mat))
                 throw Error(SWIG_TypeError, "Matrix requires the use of Fortran order.");
@@ -256,6 +267,8 @@ namespace OpenMEEG {
                 throw Error(SWIG_TypeError, "SymMatrix are stored as 1 dimensional arrays.");
 
             PyArrayObject* mat = reinterpret_cast<PyArrayObject*>(PyArray_FromObject(pyobj,NPY_DOUBLE,1,1));
+            if (mat==nullptr)
+                throw Error(SWIG_ValueError,"SymMatrix cannot be converted into an array of double.");
 
             if (!PyArray_ISFARRAY(mat))
                 throw Error(SWIG_TypeError, "SymMatrixMatrix requires the use of Fortran order.");
@@ -306,13 +319,13 @@ namespace OpenMEEG {
         if (pyobj==nullptr || !PyArray_Check(pyobj))
             throw Error(SWIG_TypeError,"Matrix of triangles should be an array.");
 
-        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(pyobj);
-        if (PyArray_SIZE(array)==0) {
+        PyArrayObject* orig_array = reinterpret_cast<PyArrayObject*>(pyobj);
+        if (PyArray_SIZE(orig_array)==0) {
             std::ostringstream oss;
             oss << "Matrix of triangles for mesh \"" << mesh->name() << "\" was empty";
             throw Error(SWIG_ValueError,oss.str().c_str());
         }
-        const PyArray_Descr* descr = PyArray_DESCR(array);
+        const PyArray_Descr* descr = PyArray_DESCR(orig_array);
         const int type_num = descr->type_num;
         if (!PyArray_EquivTypenums(type_num,NPY_INT32) &&
             !PyArray_EquivTypenums(type_num,NPY_UINT32) &&
@@ -323,32 +336,50 @@ namespace OpenMEEG {
             throw Error(SWIG_TypeError, oss.str().c_str());
         }
 
-        const size_t ndims = PyArray_NDIM(array);
+        const size_t ndims = PyArray_NDIM(orig_array);
         if (ndims!=2)
             throw Error(SWIG_TypeError,"Matrix of triangles must be a 2 dimensional array.");
 
-        const size_t nbTriangles  = PyArray_DIM(array,0);
-        if (PyArray_DIM(array,1)!=3)
+        const size_t nbTriangles  = PyArray_DIM(orig_array,0);
+        if (PyArray_DIM(orig_array,1)!=3)
             throw Error(SWIG_TypeError,"Matrix of triangles requires exactly 3 columns, standing for indices of 3 vertices.");
 
-        mesh->reference_vertices(indmap);
+        // Canonicalize to a native-byte-order, contiguous int64 array so
+        // that the raw buffer below can be read safely regardless of the
+        // original dtype's byte order or itemsize (e.g. big-endian int32,
+        // see gh-817). PyArray_FROM_OTF performs an actual value-preserving
+        // cast (not a reinterpretation), so byte-swapped inputs are handled
+        // correctly; it returns the same object (refcounted) when the input
+        // already satisfies these requirements.
+        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(
+            PyArray_FROM_OTF(pyobj,NPY_INT64,NPY_ARRAY_IN_ARRAY | NPY_ARRAY_FORCECAST));
+        if (array==nullptr)
+            throw Error(SWIG_ValueError,"Matrix of triangles cannot be converted to a matrix of int64.");
 
-        auto get_vertex = [&](PyArrayObject* mat,const int i,const int j) {
-            const unsigned vi = *reinterpret_cast<unsigned*>(PyArray_GETPTR2(mat,i,j));
-            if (vi>=indmap.size()) {
-                std::ostringstream oss;
-                oss << "Vertex index " << vi << " in triangle " << i << " out of range";
-                throw Error(SWIG_ValueError,oss.str().c_str());
+        try {
+            mesh->reference_vertices(indmap);
+
+            auto get_vertex = [&](PyArrayObject* mat,const int i,const int j) {
+                const npy_int64 vi = *reinterpret_cast<npy_int64*>(PyArray_GETPTR2(mat,i,j));
+                if (vi<0 || static_cast<size_t>(vi)>=indmap.size()) {
+                    std::ostringstream oss;
+                    oss << "Vertex index " << vi << " in triangle " << i << " out of range";
+                    throw Error(SWIG_ValueError,oss.str().c_str());
+                }
+                return &(mesh->geometry().vertices().at(indmap.at(vi)));
+            };
+
+            for (int unsigned i=0; i<nbTriangles; ++i) {
+                Vertex* v1 = get_vertex(array,i,0);
+                Vertex* v2 = get_vertex(array,i,1);
+                Vertex* v3 = get_vertex(array,i,2);
+                mesh->triangles().push_back(Triangle(v1,v2,v3));
             }
-            return &(mesh->geometry().vertices().at(indmap.at(vi)));
-        };
-
-        for (int unsigned i=0; i<nbTriangles; ++i) {
-            Vertex* v1 = get_vertex(array,i,0);
-            Vertex* v2 = get_vertex(array,i,1);
-            Vertex* v3 = get_vertex(array,i,2);
-            mesh->triangles().push_back(Triangle(v1,v2,v3));
+        } catch (...) {
+            Py_DECREF(array);
+            throw;
         }
+        Py_DECREF(array);
     }
 %}
 
@@ -359,8 +390,21 @@ namespace OpenMEEG {
 namespace OpenMEEG {
 
     // Python -> C++
+    //
+    // These conversions run as part of SWIG's argument marshaling, which
+    // happens *before* the %exception-wrapped call to the underlying C++
+    // function. Any C++ exception thrown here (e.g. wrong dtype/shape,
+    // non-Fortran-order matrix) must therefore be caught and translated
+    // into a Python exception here directly -- otherwise it escapes
+    // uncaught and aborts the whole process (see gh-584).
     %typemap(in) Vector& {
-        $1 = new_OpenMEEG_Vector($input);
+        try {
+            $1 = new_OpenMEEG_Vector($input);
+        } catch (const Error& e) {
+            SWIG_exception_fail(e.type(),e.message().c_str());
+        } catch (const std::exception& e) {
+            SWIG_exception_fail(SWIG_RuntimeError,e.what());
+        }
     }
 
     %typemap(freearg) Vector& {
@@ -368,7 +412,13 @@ namespace OpenMEEG {
     }
 
     %typemap(in) Matrix& {
-        $1 = new_OpenMEEG_Matrix($input);
+        try {
+            $1 = new_OpenMEEG_Matrix($input);
+        } catch (const Error& e) {
+            SWIG_exception_fail(e.type(),e.message().c_str());
+        } catch (const std::exception& e) {
+            SWIG_exception_fail(SWIG_RuntimeError,e.what());
+        }
     }
 
     %typemap(freearg) Matrix& {

--- a/wrapping/python/openmeeg/tests/test_matrix.py
+++ b/wrapping/python/openmeeg/tests/test_matrix.py
@@ -61,3 +61,9 @@ def test_matrix():
     mat = om.Matrix(np.zeros((2, 2)).T)  # okay
     with pytest.raises(IndexError, match="out of range"):
         mat.value(2, 2)
+
+    # A dtype that cannot be cast to double must raise a nice exception
+    # instead of crashing (the cast used to fail silently and dereference a
+    # null pointer).
+    with pytest.raises(ValueError, match="cannot be converted"):
+        om.Matrix(np.zeros((2, 2), dtype=complex))

--- a/wrapping/python/openmeeg/tests/test_mesh.py
+++ b/wrapping/python/openmeeg/tests/test_mesh.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import pytest
 
 import openmeeg._openmeeg_wrapper as _omc
 
@@ -44,6 +45,12 @@ def test_mesh_full(data_path):
     triangles = np.array([[1, 2, 3], [2, 3, 0]], dtype=np.int64)
     check_mesh("7", vertices, triangles, True)
 
+    triangles = np.array([[1, 2, 3], [2, 3, 0]], dtype=np.int32)
+    check_mesh("8", vertices, triangles, True)
+
+    triangles = np.array([[1, 2, 3], [2, 3, 0]], dtype=np.uint32)
+    check_mesh("9", vertices, triangles, True)
+
     # test X -> should be OK
 
     data_file = os.path.join(data_path, "Head1", "Head1.tri")
@@ -66,3 +73,55 @@ def test_mesh_full(data_path):
     # T_Y = mesh_Y.triangles()
     # assert_allclose(V_X, V_Y)
     # assert_allclose(T_X, T_Y)
+
+
+def _triangle_vertex_sets(mesh):
+    # Mesh.update() may reorient triangles (reversing/rotating vertex order
+    # within a triangle) for consistency, so compare vertex *sets* per
+    # triangle rather than the exact index order.
+    return sorted(
+        frozenset(mesh.triangle(t).array().tolist()) for t in mesh.triangles()
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "<i4",
+        ">i4",
+        "<u4",
+        ">u4",
+        "<i8",
+        ">i8",
+        "<u8",
+        ">u8",
+    ],
+)
+def test_mesh_triangles_byteorder(dtype):
+    """Read triangle indices identically regardless of dtype/byte order (gh-817)."""
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]]
+    )
+    triangles_native = np.array([[1, 2, 3], [2, 3, 0]], dtype=np.int64)
+    want = _triangle_vertex_sets(_omc.Mesh(vertices, triangles_native))
+
+    triangles = triangles_native.astype(dtype)
+    got = _triangle_vertex_sets(_omc.Mesh(vertices, triangles))
+    assert got == want
+
+
+def test_mesh_triangles_non_contiguous():
+    """Non-contiguous (strided) triangle arrays must be read correctly."""
+    vertices = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 1.0, 0.0]]
+    )
+    triangles_native = np.array([[1, 2, 3], [2, 3, 0]], dtype=np.int64)
+    want = _triangle_vertex_sets(_omc.Mesh(vertices, triangles_native))
+
+    # Add a padding column and slice it back off with basic (view-producing)
+    # slicing, so the resulting array is not C-contiguous.
+    padded = np.array([[1, 2, 3, 99], [2, 3, 0, 99]], dtype=np.int64)
+    triangles = padded[:, :3]
+    assert not triangles.flags["C_CONTIGUOUS"]
+    got = _triangle_vertex_sets(_omc.Mesh(vertices, triangles))
+    assert got == want

--- a/wrapping/python/openmeeg/tests/test_sensors.py
+++ b/wrapping/python/openmeeg/tests/test_sensors.py
@@ -1,8 +1,36 @@
 import os.path as op
 
 import numpy as np
+import pytest
 
 import openmeeg as om
+
+
+def test_sensors_bad_matrix_layout_raises():
+    """A non-Fortran-order Matrix argument must raise, not crash (gh-584)."""
+    labels = ["toto", "tata"]
+    positions = np.array([[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]])  # C order, not F
+    assert not positions.flags["F_CONTIGUOUS"]
+    orientations = np.array([[-1.0, -1.0, -2.0], [-1.0, -1.0, -2.0]], order="F")
+    weights = np.array([0.5, 0.5])
+    radii = np.array([1.0, 1.0])
+    with pytest.raises(Exception, match="Fortran order"):
+        om.Sensors(labels, positions, orientations, weights, radii)
+
+
+def test_sensors_non_contiguous_vector():
+    """Read non-contiguous weights/radii correctly, not silently misread (gh-584)."""
+    labels = ["toto", "tata"]
+    positions = np.array([[0, 1, 2], [0, 1, 2]], order="F", dtype=float)
+    orientations = np.array([[-1, -1, -2], [-1, -1, -2]], order="F", dtype=float)
+    # Slice out of larger arrays so weights/radii are non-contiguous views.
+    weights = np.array([[0.5, -1.0], [0.75, -1.0]])[:, 0]
+    radii = np.array([[1.0, -1.0], [2.0, -1.0]])[:, 0]
+    assert not weights.flags["C_CONTIGUOUS"]
+    assert not radii.flags["C_CONTIGUOUS"]
+    s = om.Sensors(labels, positions, orientations, weights, radii)
+    np.testing.assert_array_equal(s.getWeights().array(), weights)
+    np.testing.assert_array_equal(s.getRadii().array(), radii)
 
 
 def test_sensors(data_path):

--- a/wrapping/python/openmeeg/tests/test_symmatrix.py
+++ b/wrapping/python/openmeeg/tests/test_symmatrix.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
 import openmeeg as om
@@ -28,3 +29,9 @@ def test_symmatrix():
 
     XX = om.SymMatrix(Z)
     assert_array_equal(XX.array_flat(), Z)
+
+    # A dtype that cannot be cast to double must raise a nice exception
+    # instead of crashing (the cast used to fail silently and dereference a
+    # null pointer).
+    with pytest.raises(ValueError, match="cannot be converted"):
+        om.SymMatrix(np.zeros(3, dtype=complex))

--- a/wrapping/python/openmeeg/tests/test_vector.py
+++ b/wrapping/python/openmeeg/tests/test_vector.py
@@ -51,3 +51,18 @@ def test_vector():
     vec = _omc.Vector(3)
     with pytest.raises(IndexError, match="Index out of range"):
         vec.value(3)
+
+    # A 2D array must raise a nice exception, not crash (gh-584): this goes
+    # through the same Vector& typemap used e.g. by om.Sensors' weights and
+    # radii arguments.
+    with pytest.raises(ValueError, match="1 dimensional"):
+        _omc.Vector(np.zeros((2, 2)), _omc.DEEP_COPY)
+
+
+def test_vector_non_contiguous():
+    """Read non-contiguous input arrays correctly, not silently misread (gh-584)."""
+    padded = np.array([[1.0, -1.0], [2.0, -1.0], [3.0, -1.0]])
+    strided = padded[:, 0]
+    assert not strided.flags["C_CONTIGUOUS"]
+    V = _omc.Vector(strided, _omc.DEEP_COPY)
+    np.testing.assert_array_equal(V.array(), strided)


### PR DESCRIPTION
Closes #817
Helps with #584

Used Claude Opus 4.8 to help with this, but I understand (at least as much as I do with anything `swig`-related!) and vouch for the code.