### PR TITLE
Make the i/o layer thread-safe

### DIFF
--- a/OpenMEEG/include/GeometryIO.h
+++ b/OpenMEEG/include/GeometryIO.h
@@ -71,12 +71,10 @@ namespace OpenMEEG {
 
         static Registery registery;
 
-        //  Only prototypes register, see MeshIO.h.
+        struct Prototype { };  //  Only the prototypes register, see MeshIO.h.
 
-        GeometryIO(const std::string& filename,const char* name): fname(filename) {
-            if (filename.empty())
-                registery.insert({ name, this });
-        }
+        GeometryIO(Prototype,const char* name) { registery.insert({ name, this }); }
+        GeometryIO(const std::string& filename): fname(filename) { }
 
         std::string fname;
     };

--- a/OpenMEEG/include/GeometryIO.h
+++ b/OpenMEEG/include/GeometryIO.h
@@ -71,7 +71,12 @@ namespace OpenMEEG {
 
         static Registery registery;
 
-        GeometryIO(const std::string& filename,const char* name): fname(filename) { registery.insert({ name, this }); }
+        //  Only prototypes register, see MeshIO.h.
+
+        GeometryIO(const std::string& filename,const char* name): fname(filename) {
+            if (filename.empty())
+                registery.insert({ name, this });
+        }
 
         std::string fname;
     };

--- a/OpenMEEG/include/GeometryIOs/GeomFile.h
+++ b/OpenMEEG/include/GeometryIOs/GeomFile.h
@@ -140,7 +140,9 @@ namespace OpenMEEG::GeometryIOs {
             return res;
         }
 
-        GeomFile(const std::string& filename=""): base(filename,"geom") { }
+        GeomFile(): base(Prototype{},"geom") { }
+
+        GeomFile(const std::string& filename): base(filename) { }
 
         ~GeomFile() { ifs.close(); }
 

--- a/OpenMEEG/include/GeometryIOs/vtp.h
+++ b/OpenMEEG/include/GeometryIOs/vtp.h
@@ -245,7 +245,9 @@ namespace OpenMEEG::GeometryIOs {
 
         GeometryIO* clone(const std::string& filename) const override { return new Vtp(filename); }
 
-        Vtp(const std::string& filename=""): base(filename,"vtp") { }
+        Vtp(): base(Prototype{},"vtp") { }
+
+        Vtp(const std::string& filename): base(filename) { }
 
         static const Vtp prototype;
 
@@ -279,7 +281,9 @@ namespace OpenMEEG::GeometryIOs {
 
         GeometryIO* clone(const std::string& filename) const override { return new Vtp(filename); }
 
-        Vtp(const std::string& filename=""): base(filename,"vtp") { }
+        Vtp(): base(Prototype{},"vtp") { }
+
+        Vtp(const std::string& filename): base(filename) { }
 
         static const Vtp prototype;
     };

--- a/OpenMEEG/include/MeshIO.h
+++ b/OpenMEEG/include/MeshIO.h
@@ -90,13 +90,14 @@ namespace OpenMEEG {
 
         static Registery registery;
 
-        //  Only prototypes (empty filename) register; create() clones with a real one.
-        //  Keeps registery immutable after static init, so create() reads need no lock.
+        struct Prototype { };  //  Tag selecting the registering constructor.
 
-        MeshIO(const std::string& filename,const char* name): fname(filename) {
-            if (filename.empty())
-                registery.insert({ name, this });
-        }
+        //  Only the prototypes register; create() clones with a real file name. The
+        //  registery is therefore immutable after static initialisation, so create()
+        //  can read it from several threads without locking.
+
+        MeshIO(Prototype,const char* name) { registery.insert({ name, this }); }
+        MeshIO(const std::string& filename): fname(filename) { }
 
         std::string  fname;
         std::fstream fs;

--- a/OpenMEEG/include/MeshIO.h
+++ b/OpenMEEG/include/MeshIO.h
@@ -90,7 +90,13 @@ namespace OpenMEEG {
 
         static Registery registery;
 
-        MeshIO(const std::string& filename,const char* name): fname(filename) { registery.insert({ name, this }); }
+        //  Only prototypes (empty filename) register; create() clones with a real one.
+        //  Keeps registery immutable after static init, so create() reads need no lock.
+
+        MeshIO(const std::string& filename,const char* name): fname(filename) {
+            if (filename.empty())
+                registery.insert({ name, this });
+        }
 
         std::string  fname;
         std::fstream fs;

--- a/OpenMEEG/include/MeshIOs/Unavailable.h
+++ b/OpenMEEG/include/MeshIOs/Unavailable.h
@@ -43,8 +43,11 @@ namespace OpenMEEG::MeshIOs {
 
     protected:
 
+        //  Unavailable formats only ever exist as prototypes: clone() below hands back
+        //  this same object after complaining, it never constructs a new one.
+
         Unavailable(const char* name,const char* extension,const char* cmake):
-            base("",extension),ioname(name),cmakevar(cmake)
+            base(Prototype{},extension),ioname(name),cmakevar(cmake)
         { }
 
     private:

--- a/OpenMEEG/include/MeshIOs/bnd.h
+++ b/OpenMEEG/include/MeshIOs/bnd.h
@@ -100,7 +100,9 @@ namespace OpenMEEG::MeshIOs {
 
     private:
 
-        Bnd(const std::string& filename=""): base(filename,"bnd") { }
+        Bnd(): base(Prototype{},"bnd") { }
+
+        Bnd(const std::string& filename): base(filename) { }
 
         static const Bnd prototype;
 

--- a/OpenMEEG/include/MeshIOs/gifti.h
+++ b/OpenMEEG/include/MeshIOs/gifti.h
@@ -136,7 +136,9 @@ namespace OpenMEEG::MeshIOs {
 
         MeshIO* clone(const std::string& filename) const override { return new Gifti(filename); }
 
-        Gifti(const std::string& filename=""): base(filename,"gii") { }
+        Gifti(): base(Prototype{},"gii") { }
+
+        Gifti(const std::string& filename): base(filename) { }
 
         template <typename T>
         void read_pts(const void* data,Geometry& geom) {
@@ -168,7 +170,7 @@ namespace OpenMEEG::MeshIOs {
 #else
     struct OPENMEEG_EXPORT Gifti: public Unavailable {
 
-        Gifti(const std::string& /* filename */=""): Unavailable("GIFTI","gii","USE_GIFTI") { }
+        Gifti(): Unavailable("GIFTI","gii","USE_GIFTI") { }
 
         static const Gifti prototype;
     };

--- a/OpenMEEG/include/MeshIOs/mesh.h
+++ b/OpenMEEG/include/MeshIOs/mesh.h
@@ -159,7 +159,9 @@ namespace OpenMEEG::MeshIOs {
 
         bool binary() const override { return true; }
 
-        Mesh(const std::string& filename=""): base(filename,"mesh") { }
+        Mesh(): base(Prototype{},"mesh") { }
+
+        Mesh(const std::string& filename): base(filename) { }
 
         static const Mesh prototype;
 

--- a/OpenMEEG/include/MeshIOs/off.h
+++ b/OpenMEEG/include/MeshIOs/off.h
@@ -78,7 +78,9 @@ namespace OpenMEEG::MeshIOs {
 
     private:
 
-        Off(const std::string& filename=""): base(filename,"off") { }
+        Off(): base(Prototype{},"off") { }
+
+        Off(const std::string& filename): base(filename) { }
 
         static const Off prototype;
 

--- a/OpenMEEG/include/MeshIOs/tri.h
+++ b/OpenMEEG/include/MeshIOs/tri.h
@@ -72,7 +72,9 @@ namespace OpenMEEG::MeshIOs {
 
         MeshIO* clone(const std::string& filename) const override { return new Tri(filename); }
 
-        Tri(const std::string& filename=""): base(filename,"tri") { }
+        Tri(): base(Prototype{},"tri") { }
+
+        Tri(const std::string& filename): base(filename) { }
 
         static const Tri prototype;
 

--- a/OpenMEEG/include/MeshIOs/vtk.h
+++ b/OpenMEEG/include/MeshIOs/vtk.h
@@ -133,7 +133,9 @@ namespace OpenMEEG::MeshIOs {
 
     private:
 
-        Vtk(const std::string& filename=""): base(filename,"vtk") { }
+        Vtk(): base(Prototype{},"vtk") { }
+
+        Vtk(const std::string& filename): base(filename) { }
 
         #ifdef USE_VTK
         char*                        buffer = nullptr;

--- a/OpenMEEG/include/logger.h
+++ b/OpenMEEG/include/logger.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <iostream>
 #include <NullStream.h>
 
@@ -17,7 +18,9 @@ namespace OpenMEEG {
     class Logger {
     public:
 
-        Logger() { }
+        //  DEBUG is what the previously uninitialised, zero-initialised singleton got.
+
+        Logger(): verbosity(DEBUG) { }
 
         void set_info_level(const InfoLevel level) { verbosity = level; }
 
@@ -32,12 +35,14 @@ namespace OpenMEEG {
 
     private:
 
-        InfoLevel verbosity;
+        std::atomic<InfoLevel> verbosity; // set_info_level() can race with logging.
     };
 
     inline std::ostream&
     log_stream(const InfoLevel level) {
-        static NullStream<char> nullstream;
+        //  thread_local: callers write to it, so a shared streambuf would race.
+
+        static thread_local NullStream<char> nullstream;
         if (level==WARNING && Logger::logger().is_verbose(level))
             std::cout << "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" << std::endl
                       << "!!!!!!!!!!! WARNING !!!!!!!!!!!" << std::endl

--- a/OpenMEEGMaths/include/AsciiIO.H
+++ b/OpenMEEGMaths/include/AsciiIO.H
@@ -31,7 +31,7 @@ namespace OpenMEEG {
 
             bool known(const LinOp&) const { return true; }
 
-            LinOpInfo info(std::ifstream& is) const {
+            LinOpInfo info(const std::string&,std::ifstream& is) const {
                 is.clear();
                 is.seekg(0,std::ios::beg);
 
@@ -67,12 +67,12 @@ namespace OpenMEEG {
                 return linop;
             }
 
-            void read(std::ifstream& is,LinOp& linop) const {
+            void read(const std::string& filename,std::ifstream& is,LinOp& linop) const {
 
-                const LinOpInfo& inforead = info(is);
+                const LinOpInfo& inforead = info(filename,is);
 
                 if (linop.storageType()!=inforead.storageType())
-                    throw BadStorageType("AsciiIO reading of " + name());
+                    throw BadStorageType("AsciiIO reading of " + filename);
 
                 if (linop.dimension()!=inforead.dimension())
                     throw BadVector(inforead.ncol());
@@ -91,7 +91,7 @@ namespace OpenMEEG {
                 }
             }
 
-            void write(std::ofstream& os,const LinOp& linop) const {
+            void write(const std::string&,std::ofstream& os,const LinOp& linop) const {
                 switch (linop.storageType()) {
                     case LinOp::SPARSE :
                         write_sparse(os,linop);

--- a/OpenMEEGMaths/include/AsciiIO.H
+++ b/OpenMEEGMaths/include/AsciiIO.H
@@ -31,7 +31,7 @@ namespace OpenMEEG {
 
             bool known(const LinOp&) const { return true; }
 
-            LinOpInfo info(const std::string&,std::ifstream& is) const {
+            LinOpInfo info(std::ifstream& is) const {
                 is.clear();
                 is.seekg(0,std::ios::beg);
 
@@ -67,12 +67,12 @@ namespace OpenMEEG {
                 return linop;
             }
 
-            void read(const std::string& filename,std::ifstream& is,LinOp& linop) const {
+            void read(std::ifstream& is,LinOp& linop) const {
 
-                const LinOpInfo& inforead = info(filename,is);
+                const LinOpInfo& inforead = info(is);
 
                 if (linop.storageType()!=inforead.storageType())
-                    throw BadStorageType("AsciiIO reading of " + filename);
+                    throw BadStorageType("AsciiIO reading of " + name());
 
                 if (linop.dimension()!=inforead.dimension())
                     throw BadVector(inforead.ncol());
@@ -91,7 +91,7 @@ namespace OpenMEEG {
                 }
             }
 
-            void write(const std::string&,std::ofstream& os,const LinOp& linop) const {
+            void write(std::ofstream& os,const LinOp& linop) const {
                 switch (linop.storageType()) {
                     case LinOp::SPARSE :
                         write_sparse(os,linop);
@@ -110,7 +110,10 @@ namespace OpenMEEG {
         private:
 
             AsciiIO(): MathsIOBase(9) {}
+            AsciiIO(const std::string& filename): MathsIOBase(filename) {}
             ~AsciiIO() {};
+
+            MathsIOBase* clone(const std::string& filename) const { return new AsciiIO(filename); }
 
             static unsigned length(const std::string& line) {
                 std::stringstream buffer(line);

--- a/OpenMEEGMaths/include/BrainVisaTextureIO.H
+++ b/OpenMEEGMaths/include/BrainVisaTextureIO.H
@@ -32,14 +32,14 @@ namespace OpenMEEG {
                 return linop.storageType()==LinOp::FULL && linop.dimension()==2;
             }
 
-            LinOpInfo info(std::ifstream& is) const {
+            LinOpInfo info(const std::string&,std::ifstream& is) const {
                 Dimension nlin,ncol;
                 read_header(is,nlin,ncol);
                 is.seekg(0,std::ios_base::beg);
                 return LinOpInfo(nlin,ncol,LinOpInfo::FULL,2);
             }
 
-            void read(std::ifstream& is,LinOp& linop) const {
+            void read(const std::string&,std::ifstream& is,LinOp& linop) const {
                 Matrix& m = dynamic_cast<Matrix&>(linop);
                 read_header(is,m.nlin(),m.ncol());
                 if (linop.dimension()==1 && m.ncol()!=1)
@@ -60,7 +60,7 @@ namespace OpenMEEG {
                 }
             }
 
-            void write(std::ofstream& os,const LinOp& linop) const {
+            void write(const std::string&,std::ofstream& os,const LinOp& linop) const {
                 const Matrix& m = dynamic_cast<const Matrix&>(linop);
 
                 os << "ascii" << std::endl << "FLOAT" << std::endl << static_cast<unsigned>(m.ncol()) << std::endl;

--- a/OpenMEEGMaths/include/BrainVisaTextureIO.H
+++ b/OpenMEEGMaths/include/BrainVisaTextureIO.H
@@ -32,14 +32,14 @@ namespace OpenMEEG {
                 return linop.storageType()==LinOp::FULL && linop.dimension()==2;
             }
 
-            LinOpInfo info(const std::string&,std::ifstream& is) const {
+            LinOpInfo info(std::ifstream& is) const {
                 Dimension nlin,ncol;
                 read_header(is,nlin,ncol);
                 is.seekg(0,std::ios_base::beg);
                 return LinOpInfo(nlin,ncol,LinOpInfo::FULL,2);
             }
 
-            void read(const std::string&,std::ifstream& is,LinOp& linop) const {
+            void read(std::ifstream& is,LinOp& linop) const {
                 Matrix& m = dynamic_cast<Matrix&>(linop);
                 read_header(is,m.nlin(),m.ncol());
                 if (linop.dimension()==1 && m.ncol()!=1)
@@ -60,7 +60,7 @@ namespace OpenMEEG {
                 }
             }
 
-            void write(const std::string&,std::ofstream& os,const LinOp& linop) const {
+            void write(std::ofstream& os,const LinOp& linop) const {
                 const Matrix& m = dynamic_cast<const Matrix&>(linop);
 
                 os << "ascii" << std::endl << "FLOAT" << std::endl << static_cast<unsigned>(m.ncol()) << std::endl;
@@ -75,7 +75,10 @@ namespace OpenMEEG {
         private:
 
             BrainVisaTextureIO(): MathsIOBase(8) { }
+            BrainVisaTextureIO(const std::string& filename): MathsIOBase(filename) { }
             ~BrainVisaTextureIO() {};
+
+            MathsIOBase* clone(const std::string& filename) const { return new BrainVisaTextureIO(filename); }
 
             static void read_header(std::ifstream& is,Dimension& nlin,Dimension& ncol) {
                 is >> io_utils::match(MagicTag) >> io_utils::skip_line;

--- a/OpenMEEGMaths/include/MathsIO.H
+++ b/OpenMEEGMaths/include/MathsIO.H
@@ -32,9 +32,13 @@ namespace OpenMEEG {
 
         private:
 
-            //  thread_local: a one-shot format override must not leak across threads.
+            //  thread_local, so a one-shot format override cannot leak across threads.
+            //  Kept behind functions defined in MathsIO.C rather than as static data
+            //  members: MSVC rejects thread storage duration on a dll-exported class
+            //  (C2492), and one definition keeps every module sharing one instance.
 
-            static thread_local IO DefaultIO;
+            static IO&   current_format();
+            static bool& current_format_is_permanent();
 
         public:
 
@@ -44,9 +48,7 @@ namespace OpenMEEG {
 
             static IOs& ios() { static IOs* ios = new IOs; return *ios; }
 
-            static IO default_io() { return DefaultIO; }
-
-            static thread_local bool permanent;
+            static IO default_io() { return current_format(); }
 
             const std::string& name() const { return file_name; }
 
@@ -55,15 +57,15 @@ namespace OpenMEEG {
             //  Handle the default io.
 
             static IO GetCurrentFormat() {
-                IO tmp = DefaultIO;
-                if (!permanent)
-                    DefaultIO = 0;
+                IO tmp = current_format();
+                if (!current_format_is_permanent())
+                    current_format() = 0;
                 return tmp;
             }
 
             static void SetCurrentFormat(IO io,const bool perm=false) {
-                DefaultIO = io;
-                permanent = perm;
+                current_format() = io;
+                current_format_is_permanent() = perm;
             }
 
             static const IO& format(const std::string&);

--- a/OpenMEEGMaths/include/MathsIO.H
+++ b/OpenMEEGMaths/include/MathsIO.H
@@ -44,6 +44,7 @@ namespace OpenMEEG {
 
             MathsIO(const unsigned pr): priority(pr) { };
             MathsIO(const char* file): file_name(file),priority(0) { }
+            MathsIO(const std::string& file): file_name(file),priority(0) { }
             virtual ~MathsIO() {};
 
             static IOs& ios() { static IOs* ios = new IOs; return *ios; }
@@ -109,13 +110,16 @@ namespace OpenMEEG {
             virtual bool identify(const std::string&) const = 0;
             virtual bool known(const LinOp&) const = 0;
 
-            //  Filename passed explicitly: ios() are singletons, so stashing it on
-            //  them via setName() races as soon as two threads do i/o.
+            //  The registered ios() are prototypes shared by the whole process, so an
+            //  operation runs on a clone owning its own file name rather than mutating
+            //  the prototype, which would race as soon as two threads do i/o.
 
-            virtual LinOpInfo info(const std::string& filename,std::ifstream&) const = 0;
+            virtual MathsIOBase* clone(const std::string& filename) const = 0;
 
-            virtual void read(const std::string& filename,std::ifstream&,LinOp&) const = 0;
-            virtual void write(const std::string& filename,std::ofstream&,const LinOp&) const = 0;
+            virtual LinOpInfo info(std::ifstream&) const = 0;
+
+            virtual void read(std::ifstream&,LinOp&) const = 0;
+            virtual void write(std::ofstream&,const LinOp&) const = 0;
 
             virtual bool known_suffix(const char* suffix)  const noexcept {
                 for (const std::string& str : suffixes())
@@ -128,7 +132,10 @@ namespace OpenMEEG {
 
         protected:
 
+            //  Only the prototypes register; clones are made per operation by clone().
+
             MathsIOBase(const unsigned pr): MathsIO(pr) { base::ios().insert(this); }
+            MathsIOBase(const std::string& filename): MathsIO(filename) { }
             ~MathsIOBase() {};
         };
 

--- a/OpenMEEGMaths/include/MathsIO.H
+++ b/OpenMEEGMaths/include/MathsIO.H
@@ -32,7 +32,9 @@ namespace OpenMEEG {
 
         private:
 
-            static IO DefaultIO;
+            //  thread_local: a one-shot format override must not leak across threads.
+
+            static thread_local IO DefaultIO;
 
         public:
 
@@ -44,11 +46,9 @@ namespace OpenMEEG {
 
             static IO default_io() { return DefaultIO; }
 
-            static bool permanent;
+            static thread_local bool permanent;
 
             const std::string& name() const { return file_name; }
-
-            void setName(const std::string& n) { file_name = n; }
 
             //  This is very similar with ImageIO, how to commonize it ?
 
@@ -107,10 +107,13 @@ namespace OpenMEEG {
             virtual bool identify(const std::string&) const = 0;
             virtual bool known(const LinOp&) const = 0;
 
-            virtual LinOpInfo info(std::ifstream&) const = 0;
+            //  Filename passed explicitly: ios() are singletons, so stashing it on
+            //  them via setName() races as soon as two threads do i/o.
 
-            virtual void read(std::ifstream&,LinOp&) const = 0;
-            virtual void write(std::ofstream&,const LinOp&) const = 0;
+            virtual LinOpInfo info(const std::string& filename,std::ifstream&) const = 0;
+
+            virtual void read(const std::string& filename,std::ifstream&,LinOp&) const = 0;
+            virtual void write(const std::string& filename,std::ofstream&,const LinOp&) const = 0;
 
             virtual bool known_suffix(const char* suffix)  const noexcept {
                 for (const std::string& str : suffixes())

--- a/OpenMEEGMaths/include/MatlabIO.H
+++ b/OpenMEEGMaths/include/MatlabIO.H
@@ -130,37 +130,37 @@ namespace OpenMEEG {
                 return st==LinOpInfo::FULL || st==LinOpInfo::SYMMETRIC || st==LinOpInfo::SPARSE;
             }
 
-            LinOpInfo info(const std::string& filename,std::ifstream& is) const {
+            LinOpInfo info(std::ifstream& is) const {
                 if (is.is_open())
                     is.close();
 
                 const std::lock_guard<std::mutex> lock(matio_mutex());
 
                 LinOpInfo linop;
-                mat_t* mat = Mat_Open(filename.c_str(),MAT_ACC_RDONLY);
+                mat_t* mat = Mat_Open(name().c_str(),MAT_ACC_RDONLY);
                 if (mat) {
                     try { read_header<Vector>(mat,linop);       return finish(mat,linop); } catch(...) { Mat_Rewind(mat); }
                     try { read_header<Matrix>(mat,linop);       return finish(mat,linop); } catch(...) { Mat_Rewind(mat); }
                     try { read_header<SymMatrix>(mat,linop);    return finish(mat,linop); } catch(...) { Mat_Rewind(mat); }
                     try { read_header<SparseMatrix>(mat,linop); return finish(mat,linop); } catch(...) { }
                     Mat_Close(mat);
-                    throw ImpossibleObjectIdentification(filename);
+                    throw ImpossibleObjectIdentification(name());
                 } else {
-                    throw BadFileOpening(filename,maths::BadFileOpening::READ);
+                    throw BadFileOpening(name(),maths::BadFileOpening::READ);
                 }
                 // We can never get here based on the above return/throw combinations
             }
 
-            void read(const std::string& filename,std::ifstream& is,LinOp& linop) const {
+            void read(std::ifstream& is,LinOp& linop) const {
                 if (is.is_open()) {
                     is.close();
                 }
 
                 const std::lock_guard<std::mutex> lock(matio_mutex());
 
-                mat_t* mat = Mat_Open(filename.c_str(),MAT_ACC_RDONLY);
+                mat_t* mat = Mat_Open(name().c_str(),MAT_ACC_RDONLY);
                 if (!mat)
-                    throw BadFileOpening(filename,maths::BadFileOpening::READ);
+                    throw BadFileOpening(name(),maths::BadFileOpening::READ);
 
                 if (linop.dimension()==1)
                     read<Vector>(mat,linop);
@@ -177,7 +177,7 @@ namespace OpenMEEG {
                             break;
                         default: {
                             Mat_Close(mat);
-                            throw BadStorageType(filename);
+                            throw BadStorageType(name());
                         }
                     }
                 }
@@ -185,17 +185,17 @@ namespace OpenMEEG {
                 Mat_Close(mat);
             }
 
-            void write(const std::string& filename,std::ofstream& os,const LinOp& linop) const {
+            void write(std::ofstream& os,const LinOp& linop) const {
                 if (os.is_open()) {
                     os.close();
-                    std::remove(filename.c_str());
+                    std::remove(name().c_str());
                 }
 
                 const std::lock_guard<std::mutex> lock(matio_mutex());
 
-                mat_t* mat = Mat_CreateVer(filename.c_str(),NULL,MAT_FT_MAT73);
+                mat_t* mat = Mat_CreateVer(name().c_str(),NULL,MAT_FT_MAT73);
                 if (!mat)
-                    throw BadFileOpening(filename,maths::BadFileOpening::WRITE);
+                    throw BadFileOpening(name(),maths::BadFileOpening::WRITE);
 
                 if (linop.dimension()==1)
                     write<Vector>(mat,linop);
@@ -211,7 +211,7 @@ namespace OpenMEEG {
                             write<Matrix>(mat,linop);
                             break;
                         default:
-                            throw BadStorageType(filename);
+                            throw BadStorageType(name());
                     }
                 }
 
@@ -255,9 +255,14 @@ namespace OpenMEEG {
                 std::cerr << error << message << std::endl;
             }
 
+            //  Only the prototype touches matio's global log hook.
+
             MatlabIO(): MathsIOBase(5) { Mat_LogInitFunc("OpenMEEG",matiologfunc); }
+            MatlabIO(const std::string& filename): MathsIOBase(filename) { }
 
             ~MatlabIO() {};
+
+            MathsIOBase* clone(const std::string& filename) const { return new MatlabIO(filename); }
 
             template <typename TYPE>
             matvar_t* read_header(mat_t* mat,LinOpInfo& linop) const {

--- a/OpenMEEGMaths/include/MatlabIO.H
+++ b/OpenMEEGMaths/include/MatlabIO.H
@@ -9,6 +9,8 @@
 
 #include <matio.h>
 
+#include <mutex>
+
 #include <OMMathExceptions.H>
 #include "MathsIO.H"
 #include "sparse_matrix.h"
@@ -128,32 +130,37 @@ namespace OpenMEEG {
                 return st==LinOpInfo::FULL || st==LinOpInfo::SYMMETRIC || st==LinOpInfo::SPARSE;
             }
 
-            LinOpInfo info(std::ifstream& is) const {
+            LinOpInfo info(const std::string& filename,std::ifstream& is) const {
                 if (is.is_open())
                     is.close();
 
+                const std::lock_guard<std::mutex> lock(matio_mutex());
+
                 LinOpInfo linop;
-                mat_t* mat = Mat_Open(name().c_str(),MAT_ACC_RDONLY);
+                mat_t* mat = Mat_Open(filename.c_str(),MAT_ACC_RDONLY);
                 if (mat) {
                     try { read_header<Vector>(mat,linop);       return finish(mat,linop); } catch(...) { Mat_Rewind(mat); }
                     try { read_header<Matrix>(mat,linop);       return finish(mat,linop); } catch(...) { Mat_Rewind(mat); }
                     try { read_header<SymMatrix>(mat,linop);    return finish(mat,linop); } catch(...) { Mat_Rewind(mat); }
                     try { read_header<SparseMatrix>(mat,linop); return finish(mat,linop); } catch(...) { }
                     Mat_Close(mat);
-                    throw ImpossibleObjectIdentification(name());
+                    throw ImpossibleObjectIdentification(filename);
                 } else {
-                    throw BadFileOpening(name(),maths::BadFileOpening::READ);
+                    throw BadFileOpening(filename,maths::BadFileOpening::READ);
                 }
                 // We can never get here based on the above return/throw combinations
             }
 
-            void read(std::ifstream& is,LinOp& linop) const {
+            void read(const std::string& filename,std::ifstream& is,LinOp& linop) const {
                 if (is.is_open()) {
                     is.close();
                 }
-                mat_t* mat = Mat_Open(name().c_str(),MAT_ACC_RDONLY);
+
+                const std::lock_guard<std::mutex> lock(matio_mutex());
+
+                mat_t* mat = Mat_Open(filename.c_str(),MAT_ACC_RDONLY);
                 if (!mat)
-                    throw BadFileOpening(name(),maths::BadFileOpening::READ);
+                    throw BadFileOpening(filename,maths::BadFileOpening::READ);
 
                 if (linop.dimension()==1)
                     read<Vector>(mat,linop);
@@ -170,7 +177,7 @@ namespace OpenMEEG {
                             break;
                         default: {
                             Mat_Close(mat);
-                            throw BadStorageType(name());
+                            throw BadStorageType(filename);
                         }
                     }
                 }
@@ -178,14 +185,17 @@ namespace OpenMEEG {
                 Mat_Close(mat);
             }
 
-            void write(std::ofstream& os,const LinOp& linop) const {
+            void write(const std::string& filename,std::ofstream& os,const LinOp& linop) const {
                 if (os.is_open()) {
                     os.close();
-                    std::remove(name().c_str());
+                    std::remove(filename.c_str());
                 }
-                mat_t* mat = Mat_CreateVer(name().c_str(),NULL,MAT_FT_MAT73);
+
+                const std::lock_guard<std::mutex> lock(matio_mutex());
+
+                mat_t* mat = Mat_CreateVer(filename.c_str(),NULL,MAT_FT_MAT73);
                 if (!mat)
-                    throw BadFileOpening(name(),maths::BadFileOpening::WRITE);
+                    throw BadFileOpening(filename,maths::BadFileOpening::WRITE);
 
                 if (linop.dimension()==1)
                     write<Vector>(mat,linop);
@@ -201,7 +211,7 @@ namespace OpenMEEG {
                             write<Matrix>(mat,linop);
                             break;
                         default:
-                            throw BadStorageType(name());
+                            throw BadStorageType(filename);
                     }
                 }
 
@@ -209,6 +219,16 @@ namespace OpenMEEG {
             }
 
         private:
+
+            //  matio and HDF5 keep non-reentrant global state and are not built
+            //  thread-safe, so serialise every entry point. Also covers the static
+            //  scratch in details::helper<>.
+
+            static std::mutex& matio_mutex() {
+                static std::mutex m;
+                return m;
+            }
+
             #if MATIO_VERSION>=1527
             static void matiologfunc(int log_level,const char* message) {
             #else

--- a/OpenMEEGMaths/include/TrivialBinIO.H
+++ b/OpenMEEGMaths/include/TrivialBinIO.H
@@ -31,7 +31,7 @@ namespace OpenMEEG {
                 \sa
             **/
 
-            LinOpInfo info(std::ifstream& is) const {
+            LinOpInfo info(const std::string&,std::ifstream& is) const {
 
                 //  Get the size of the file.
 
@@ -68,19 +68,19 @@ namespace OpenMEEG {
                 return linop;
             }
 
-            void read(std::ifstream& is,LinOp& linop) const {
-                const LinOpInfo& inforead = info(is);
+            void read(const std::string& filename,std::ifstream& is,LinOp& linop) const {
+                const LinOpInfo& inforead = info(filename,is);
 
                 if (linop.storageType()!=inforead.storageType()) {
                     std::ostringstream oss;
                     oss << "TrivialBinIO linop.storageType (" << linop.storageType()
                         << ") != inforead.storageType (" << inforead.storageType()
-                        << ") for file " << name();
+                        << ") for file " << filename;
                     throw BadStorageType(oss.str());
                 }
 
                 if (linop.dimension()!=inforead.dimension())
-                    throw BadStorageType("TrivialBinIO dimension during read of "+name());
+                    throw BadStorageType("TrivialBinIO dimension during read of "+filename);
 
                 linop.nlin() = inforead.nlin();
                 linop.ncol() = inforead.ncol();
@@ -104,7 +104,7 @@ namespace OpenMEEG {
                 }
             }
 
-            void write(std::ofstream& os,const LinOp& linop) const {
+            void write(const std::string&,std::ofstream& os,const LinOp& linop) const {
 
                 //  Write the header.
 

--- a/OpenMEEGMaths/include/TrivialBinIO.H
+++ b/OpenMEEGMaths/include/TrivialBinIO.H
@@ -31,7 +31,7 @@ namespace OpenMEEG {
                 \sa
             **/
 
-            LinOpInfo info(const std::string&,std::ifstream& is) const {
+            LinOpInfo info(std::ifstream& is) const {
 
                 //  Get the size of the file.
 
@@ -68,19 +68,19 @@ namespace OpenMEEG {
                 return linop;
             }
 
-            void read(const std::string& filename,std::ifstream& is,LinOp& linop) const {
-                const LinOpInfo& inforead = info(filename,is);
+            void read(std::ifstream& is,LinOp& linop) const {
+                const LinOpInfo& inforead = info(is);
 
                 if (linop.storageType()!=inforead.storageType()) {
                     std::ostringstream oss;
                     oss << "TrivialBinIO linop.storageType (" << linop.storageType()
                         << ") != inforead.storageType (" << inforead.storageType()
-                        << ") for file " << filename;
+                        << ") for file " << name();
                     throw BadStorageType(oss.str());
                 }
 
                 if (linop.dimension()!=inforead.dimension())
-                    throw BadStorageType("TrivialBinIO dimension during read of "+filename);
+                    throw BadStorageType("TrivialBinIO dimension during read of "+name());
 
                 linop.nlin() = inforead.nlin();
                 linop.ncol() = inforead.ncol();
@@ -104,7 +104,7 @@ namespace OpenMEEG {
                 }
             }
 
-            void write(const std::string&,std::ofstream& os,const LinOp& linop) const {
+            void write(std::ofstream& os,const LinOp& linop) const {
 
                 //  Write the header.
 
@@ -195,7 +195,10 @@ namespace OpenMEEG {
             }
 
             TrivialBinIO(): MathsIOBase(20) { }
+            TrivialBinIO(const std::string& filename): MathsIOBase(filename) { }
             ~TrivialBinIO() {};
+
+            MathsIOBase* clone(const std::string& filename) const { return new TrivialBinIO(filename); }
 
             static Suffixes init() {
                 Suffixes suffixes;

--- a/OpenMEEGMaths/src/MathsIO.C
+++ b/OpenMEEGMaths/src/MathsIO.C
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "MathsIO.H"
 
 namespace OpenMEEG {
@@ -29,6 +31,24 @@ namespace OpenMEEG {
 
                 return std::string(buffer);
             }
+
+            //  Owns the clone an io prototype makes for one operation. Ownership is
+            //  held as a MathsIO*, whose destructor is public and virtual, because
+            //  ~MathsIOBase() is protected.
+
+            class Operation {
+            public:
+
+                Operation(const MathsIO::IO proto,const std::string& filename):
+                    io(proto->clone(filename)),owner(io) { }
+
+                MathsIOBase* operator->() const { return io; }
+
+            private:
+
+                MathsIOBase* const             io;
+                const std::unique_ptr<MathsIO> owner;
+            };
         }
 
         MathsIO::IO& MathsIO::current_format() {
@@ -67,17 +87,22 @@ namespace OpenMEEG {
 
             const std::string& buffer = Internal::ReadTag(is);
 
+            //  linop.default_io() keeps the prototype, which outlives the operation:
+            //  the clone below is gone by the time anyone looks at it.
+
             if (maths::MathsIO::IO dio = maths::MathsIO::GetCurrentFormat()) {
                 if (dio->identify(buffer)) {
-                    dio->read(mio.name(),is,linop);
+                    Internal::Operation io(dio,mio.name());
+                    io->read(is,linop);
                     linop.default_io() = dio;
                     return mio;
                 }
             } else {
-                for (const maths::MathsIO::IO& io : MathsIO::ios())
-                    if (io->identify(buffer)) {
-                        io->read(mio.name(),is,linop);
-                        linop.default_io() = io;
+                for (const maths::MathsIO::IO& proto : MathsIO::ios())
+                    if (proto->identify(buffer)) {
+                        Internal::Operation io(proto,mio.name());
+                        io->read(is,linop);
+                        linop.default_io() = proto;
                         return mio;
                     }
             }
@@ -92,13 +117,15 @@ namespace OpenMEEG {
 
             if (maths::MathsIO::IO dio = maths::MathsIO::GetCurrentFormat()) {
                 if (dio->known(linop)) {
-                    dio->write(mio.name(),os,linop);
+                    Internal::Operation io(dio,mio.name());
+                    io->write(os,linop);
                     return mio;
                 }
             } else {
-                for (const maths::MathsIO::IO& io : MathsIO::ios())
-                    if (io->known(linop)) {
-                        io->write(mio.name(),os,linop);
+                for (const maths::MathsIO::IO& proto : MathsIO::ios())
+                    if (proto->known(linop)) {
+                        Internal::Operation io(proto,mio.name());
+                        io->write(os,linop);
                         return mio;
                     }
             }
@@ -114,12 +141,14 @@ namespace OpenMEEG {
 
             if (maths::MathsIO::IO dio = maths::MathsIO::default_io()) {
                 if (dio->identify(buffer)) {
-                    return dio->info(name,is);
+                    Internal::Operation io(dio,name);
+                    return io->info(is);
                 }
             } else {
-                for (const maths::MathsIO::IO& io : MathsIO::ios())
-                    if (io->identify(buffer)) {
-                        return io->info(name,is);
+                for (const maths::MathsIO::IO& proto : MathsIO::ios())
+                    if (proto->identify(buffer)) {
+                        Internal::Operation io(proto,name);
+                        return io->info(is);
                     }
             }
             throw NoIO(name,NoIO::READ);

--- a/OpenMEEGMaths/src/MathsIO.C
+++ b/OpenMEEGMaths/src/MathsIO.C
@@ -13,7 +13,7 @@ namespace OpenMEEG {
             static std::string
             ReadTag(std::istream& is) {
 
-                static char buffer[maxtagsize+1];
+                char buffer[maxtagsize+1]; // Not static: shared would corrupt concurrent readers.
 
                 try {
                     is.read(buffer,maxtagsize);
@@ -31,8 +31,8 @@ namespace OpenMEEG {
             }
         }
 
-        MathsIO::IO MathsIO::DefaultIO = 0;
-        bool MathsIO::permanent = false;
+        thread_local MathsIO::IO MathsIO::DefaultIO = 0;
+        thread_local bool MathsIO::permanent = false;
 
         const MathsIO::IO& MathsIO::format(const std::string& fmt) {
             for (const IO& io : ios())
@@ -62,16 +62,14 @@ namespace OpenMEEG {
 
             if (maths::MathsIO::IO dio = maths::MathsIO::GetCurrentFormat()) {
                 if (dio->identify(buffer)) {
-                    dio->setName(mio.name());
-                    dio->read(is,linop);
+                    dio->read(mio.name(),is,linop);
                     linop.default_io() = dio;
                     return mio;
                 }
             } else {
                 for (const maths::MathsIO::IO& io : MathsIO::ios())
                     if (io->identify(buffer)) {
-                        io->setName(mio.name());
-                        io->read(is,linop);
+                        io->read(mio.name(),is,linop);
                         linop.default_io() = io;
                         return mio;
                     }
@@ -87,15 +85,13 @@ namespace OpenMEEG {
 
             if (maths::MathsIO::IO dio = maths::MathsIO::GetCurrentFormat()) {
                 if (dio->known(linop)) {
-                    dio->setName(mio.name());
-                    dio->write(os,linop);
+                    dio->write(mio.name(),os,linop);
                     return mio;
                 }
             } else {
                 for (const maths::MathsIO::IO& io : MathsIO::ios())
                     if (io->known(linop)) {
-                        io->setName(mio.name());
-                        io->write(os,linop);
+                        io->write(mio.name(),os,linop);
                         return mio;
                     }
             }
@@ -111,14 +107,12 @@ namespace OpenMEEG {
 
             if (maths::MathsIO::IO dio = maths::MathsIO::default_io()) {
                 if (dio->identify(buffer)) {
-                    dio->setName(name);
-                    return dio->info(is);
+                    return dio->info(name,is);
                 }
             } else {
                 for (const maths::MathsIO::IO& io : MathsIO::ios())
                     if (io->identify(buffer)) {
-                        io->setName(name);
-                        return io->info(is);
+                        return io->info(name,is);
                     }
             }
             throw NoIO(name,NoIO::READ);

--- a/OpenMEEGMaths/src/MathsIO.C
+++ b/OpenMEEGMaths/src/MathsIO.C
@@ -31,8 +31,15 @@ namespace OpenMEEG {
             }
         }
 
-        thread_local MathsIO::IO MathsIO::DefaultIO = 0;
-        thread_local bool MathsIO::permanent = false;
+        MathsIO::IO& MathsIO::current_format() {
+            static thread_local IO io = 0;
+            return io;
+        }
+
+        bool& MathsIO::current_format_is_permanent() {
+            static thread_local bool perm = false;
+            return perm;
+        }
 
         const MathsIO::IO& MathsIO::format(const std::string& fmt) {
             for (const IO& io : ios())


### PR DESCRIPTION
I had Claude Opus 5 help me look into making Python 3.14t wheels, which requires looking into the OpenMEEG codebase for compatibility. It found some global state stuff in MathsIO, MeshIO, and GeometryIO. These are pretty much all fixable by passing through filenames rather than using a global state to track them. I think we can rely on CIs to ensure this stuff is okay. Claude wrote the changes and I reviewed them -- they look okay to me (but I'm not a C++ expert!).

@papadop feel free to review and merge if you're happy.

This is the more verbose description provided by Claude:

<details>
<summary>Changes</summary>

The maths and mesh i/o layers rely on shared mutable state that only the GIL was keeping safe. These are real races today for anyone using threading.Thread, and they are a prerequisite for ever declaring Py_MOD_GIL_NOT_USED for the free-threaded builds of CPython, since that declaration is a promise CPython takes at face value.

* MathsIO.C: ReadTag() read every file header into a function-level static buffer, so concurrent readers corrupted each other's format detection. Use a local buffer.

* MathsIO: the registered ios() are process-wide singletons, and operator>>, operator<< and info() each did io->setName(name) before dispatching, so the filename of a shared object was swapped for the duration of every operation. Two concurrent reads could therefore read the wrong file. Pass the filename to info()/read()/write() instead and drop setName().

* MathsIO: DefaultIO and permanent implement the one-shot format() override, and GetCurrentFormat() mutates DefaultIO to consume it. Make both thread_local: sharing them races, and one thread's format override should not be consumed by another thread's operation.

* MatlabIO: matio and the HDF5 library behind MAT 7.3 keep non-reentrant global state and are not built thread-safe here. Serialise info()/read()/write() on a private mutex. This also covers the shared static scratch buffers in details::helper<> (dims[] and saved), which are only reachable from those methods.

* MeshIO, GeometryIO: the base constructor inserted into the static registery, and create() reaches it through clone(), so every mesh or geometry load mutated a map that create() concurrently reads. Only the prototypes (the instances default-constructed with an empty filename) register now. The insert from a clone was already a no-op because the prototype owns the key, so behaviour is unchanged, and the registery is immutable once static initialisation is done -- concurrent reads then need no lock.

* logger.h: verbosity is written by set_info_level() while other threads read it, so make it atomic. It was also never initialised by the constructor and only worked because the singleton has static storage duration and was zero initialised first; initialise it to DEBUG explicitly, which is the value it previously ended up with. nullstream is written to by its callers, so make it thread_local.

The compute paths were audited for shared mutable state and are clean: what is left in OpenMEEG and OpenMEEGMaths is static member functions, thread_locals, the now-immutable registeries, and the state under the matio mutex.

Note that this changes the MathsIOBase virtuals and removes MathsIO::setName(). Both are on exported classes, but setName() had no callers outside MathsIO.C and the Python wrappers do not expose either.

Verified on macOS arm64: builds clean with -Werror -Wextra -pedantic and 692/692 ctest tests pass.

</details>