### PR TITLE
Add 3.14t wheels and modernize python wrapping

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -281,7 +281,7 @@ jobs:
         else
           pip install --upgrade --only-binary numpy "numpy>=2"
         fi
-        pip install --upgrade --progress-bar off --only-binary="numpy" -q setuptools setuptools_scm wheel twine threadpoolctl "swig>=4.2" $EXTRA_PIP
+        pip install --upgrade --progress-bar off --only-binary="numpy" -q "setuptools>=70.1" setuptools_scm twine threadpoolctl "swig>=4.2" $EXTRA_PIP
 
 
     - name: MKL setup - mkl via conda

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -87,6 +87,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # 3.13 exercises the abi3 wheel on an interpreter it was not built for;
+        # 3.14t exercises the separate free-threaded wheel.
+        python-version: ['3.13', '3.14t']
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-latest]
         include:
           - os: ubuntu-latest
             arch: x86_64
@@ -99,7 +103,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v7.0.0
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       - uses: actions/download-artifact@v8
         with:
           path: dist
@@ -121,14 +125,23 @@ jobs:
           echo "OPENMEEG_DATA_PATH=$OPENMEEG_DATA_PATH" | tee -a $GITHUB_ENV
       - run: ls -alt dist/
         shell: bash
-      - run: pip install -v pytest dist/*.whl
+      # numpy is openmeeg's only runtime dep; installing it here lets the next
+      # step stay --no-index so it can never silently pull openmeeg from PyPI.
+      - run: pip install -v pytest numpy
         shell: bash
+      # Let pip pick the wheel matching this interpreter: dist/ holds both the
+      # abi3 wheel and the free-threaded one, and only one is installable here.
+      - run: pip install -v --no-index --no-deps --find-links dist openmeeg
+        shell: bash
+      - name: Check the GIL stays disabled on free-threaded builds
+        if: endsWith(matrix.python-version, 't')
+        run: python -c "import sys, openmeeg; assert not sys._is_gil_enabled()"
       # Only exercise the om_viz plotting path on one runner, it is heavy
       - name: Install viz dependencies
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.13'
         run: pip install pyvista pyvistaqt PyQt6
       - uses: pyvista/setup-headless-display-action@v4
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu') && matrix.python-version == '3.13'
         with:
           qt: true
       - run: pytest -m "not slow" --pyargs openmeeg

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
         gcc --version
     - name: Install NumPy
       run: |
-        pip install --upgrade --user "setuptools>=68.0.0" "setuptools_scm>=6.2" "wheel>=0.37.0" "numpy>=2.0.0b1,<3" "swig>=4.2" "packaging>=24.2"
+        pip install --upgrade --user "setuptools>=70.1" "setuptools_scm>=6.2" "numpy>=2.0.0b1,<3" "swig>=4.2" "packaging>=24.2"
     - name: Configure
       run: |
         export DISABLE_CCACHE=1

--- a/OpenMEEG/include/integrator.h
+++ b/OpenMEEG/include/integrator.h
@@ -39,7 +39,7 @@ namespace OpenMEEG {
         double norm(const double a) const { return fabs(a);  }
         double norm(const Vect3& a) const { return a.norm(); }
 
-        #ifndef SWIGPYTHON  // SWIG sees the integrate def as a syntax error
+        #ifndef SWIG  // SWIG sees the integrate def as a syntax error
         template <typename Function>
         decltype(auto) integrate(const Function& function,const Triangle& triangle) const {
             const TrianglePoints tripts = { triangle.vertex(0), triangle.vertex(1), triangle.vertex(2) };
@@ -50,7 +50,7 @@ namespace OpenMEEG {
 
     private:
 
-        #ifndef SWIGPYTHON  // SWIG sees the triangle_integration def as a syntax error
+        #ifndef SWIG  // SWIG sees the triangle_integration def as a syntax error
         template <typename Function>
         decltype(auto) triangle_integration(const Function& function,const TrianglePoints& triangle,const double area) const {
             using T = decltype(function(Vect3()));

--- a/OpenMEEGMaths/include/vector.h
+++ b/OpenMEEGMaths/include/vector.h
@@ -43,6 +43,14 @@ namespace OpenMEEG {
 
         double* data() const { return value.get(); }
 
+    #if defined(SWIGPYTHON) || defined(WIN32)
+
+        // Only needed for swig wrapping, so that array() can keep the data alive
+        // behind the numpy view it hands out. See Matrix for the same method.
+
+        std::shared_ptr<double[]> get_shared_data_ptr() { return value; }
+    #endif
+
         double operator()(const Index i) const {
             om_assert(i<nlin());
             return value[i];

--- a/build_tools/cibw_abi3audit.sh
+++ b/build_tools/cibw_abi3audit.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ef
+
+# abi3audit only applies to the stable-ABI wheel. The free-threaded build has no
+# limited API at all (CPython gh-111506), so it ships a version-specific wheel that
+# abi3audit rejects outright rather than passing trivially.
+
+WHEEL="$1"
+
+case "$(basename "$WHEEL")" in
+    *-abi3-*)
+        pipx run abi3audit --strict --report "$WHEEL"
+        ;;
+    *)
+        echo "Skipping abi3audit for non-abi3 wheel: $(basename "$WHEEL")"
+        ;;
+esac

--- a/wrapping/python/CMakeLists.txt
+++ b/wrapping/python/CMakeLists.txt
@@ -15,6 +15,18 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
 endif()
 
 if (PYTHON_USE_SABI)
+    # Python.h #errors out on Py_LIMITED_API + Py_GIL_DISABLED (CPython gh-111506)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    execute_process(COMMAND ${Python3_EXECUTABLE} -c
+                    "import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))"
+                    OUTPUT_VARIABLE PYTHON_FREE_THREADED OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (PYTHON_FREE_THREADED STREQUAL "True")
+        message(WARNING "PYTHON_USE_SABI is not supported on free-threaded Python, disabling it")
+        set(PYTHON_USE_SABI OFF)
+    endif()
+endif()
+
+if (PYTHON_USE_SABI)
     find_package(Python3 REQUIRED COMPONENTS Interpreter NumPy Development.SABIModule)
 else()
     find_package(Python3 REQUIRED COMPONENTS Interpreter NumPy Development)
@@ -48,7 +60,20 @@ else()
     include(${SWIG_USE_FILE})
 endif()
 
+# "-O" without its other two flags: -fastproxy emits PyCFunctionObject and
+# PyInstanceMethod_New, neither in the limited API, and -fvirtual measured ~6.5% slower
+# here (it routes the 8 LinOp-derived size()/info() through a base-class ConvertPtr).
+# -fastdispatch is only an optimization now that the typecheck typemaps in _openmeeg.i
+# make overload resolution work without it, so it is safe to drop if it ever conflicts.
 list(APPEND CMAKE_SWIG_FLAGS -v -fastdispatch)
+# Declares Py_MOD_GIL_NOT_USED, which the i/o layer earned in gh-866; without it CPython
+# silently re-enables the GIL on free-threaded builds. Not a hard requirement, so keep
+# the SWIG floor at 4.2 for distro builds rather than requiring 4.4 everywhere.
+if (SWIG_VERSION VERSION_GREATER_EQUAL "4.4")
+    list(APPEND CMAKE_SWIG_FLAGS -nogil)
+else()
+    message(STATUS "SWIG ${SWIG_VERSION} < 4.4: no -nogil, free-threaded Python will re-enable the GIL")
+endif()
 set(SWIG_MODULE_openmeeg_EXTRA_DEPS openmeeg/numpy.i ${SWIG_MODULE_openmeeg_EXTRA_DEPS})
 set_source_files_properties(openmeeg/_openmeeg.i PROPERTIES CPLUSPLUS ON GENERATED_COMPILE_DEFINITIONS SWIG_PYTHON_SILENT_MEMLEAK SWIG_MODULE_NAME _openmeeg_wrapper)
 # This puts _openmeeg.py in openmeeg/

--- a/wrapping/python/openmeeg/_openmeeg.i
+++ b/wrapping/python/openmeeg/_openmeeg.i
@@ -205,6 +205,22 @@ namespace OpenMEEG {
 
     typedef std::shared_ptr<double[]> SharedData;
 
+    // Owns the new reference returned by PyArray_FROM_OTF/PyArray_FromObject. Those
+    // return a new array whenever the input needs converting, so dropping the
+    // reference on every path (including the throws below) matters: leaking it pinned
+    // a full converted copy of the input per call. The helpers here all copy out of
+    // the array before returning, so nothing outlives the guard.
+    class PyArrayRef {
+    public:
+        explicit PyArrayRef(PyObject* obj): arr(reinterpret_cast<PyArrayObject*>(obj)) { }
+        ~PyArrayRef() { Py_XDECREF(reinterpret_cast<PyObject*>(arr)); }
+        PyArrayRef(const PyArrayRef&) = delete;
+        PyArrayRef& operator=(const PyArrayRef&) = delete;
+        operator PyArrayObject*() const { return arr; }
+    private:
+        PyArrayObject* arr;
+    };
+
     // Creator of Vector from PyArrayObject or Vector
 
     OpenMEEG::Vector* new_OpenMEEG_Vector(PyObject* pyobj) {
@@ -213,9 +229,8 @@ namespace OpenMEEG {
             // Vector below references the raw buffer directly (no
             // element-wise copy), so a non-contiguous input (e.g. a
             // strided slice) would otherwise be silently misread.
-            PyArrayObject* vect = reinterpret_cast<PyArrayObject*>(
-                PyArray_FROM_OTF(pyobj,NPY_DOUBLE,NPY_ARRAY_IN_ARRAY));
-            if (vect==nullptr)
+            PyArrayRef vect(PyArray_FROM_OTF(pyobj,NPY_DOUBLE,NPY_ARRAY_IN_ARRAY));
+            if (static_cast<PyArrayObject*>(vect)==nullptr)
                 throw Error(SWIG_ValueError,"Vector cannot be converted into an array of double.");
             if (PyArray_NDIM(vect)!=1)
                 throw Error(SWIG_ValueError,"Vector must be a 1 dimensional array.");
@@ -243,8 +258,8 @@ namespace OpenMEEG {
             if (nbdims!=2)
                 throw Error(SWIG_TypeError,"Matrix can only have 2 dimensions.");
 
-            PyArrayObject* mat = reinterpret_cast<PyArrayObject*>(PyArray_FromObject(pyobj,NPY_DOUBLE,2,2));
-            if (mat==nullptr)
+            PyArrayRef mat(PyArray_FromObject(pyobj,NPY_DOUBLE,2,2));
+            if (static_cast<PyArrayObject*>(mat)==nullptr)
                 throw Error(SWIG_ValueError,"Matrix cannot be converted into an array of double.");
 
             if (!PyArray_ISFARRAY(mat))
@@ -273,8 +288,8 @@ namespace OpenMEEG {
             if (nbdims!=1)
                 throw Error(SWIG_TypeError,"SymMatrix are stored as 1 dimensional arrays.");
 
-            PyArrayObject* mat = reinterpret_cast<PyArrayObject*>(PyArray_FromObject(pyobj,NPY_DOUBLE,1,1));
-            if (mat==nullptr)
+            PyArrayRef mat(PyArray_FromObject(pyobj,NPY_DOUBLE,1,1));
+            if (static_cast<PyArrayObject*>(mat)==nullptr)
                 throw Error(SWIG_ValueError,"SymMatrix cannot be converted into an array of double.");
 
             if (!PyArray_ISFARRAY(mat))
@@ -303,8 +318,8 @@ namespace OpenMEEG {
         if (pyobj==nullptr || !PyArray_Check(pyobj))
             throw Error(SWIG_TypeError,"Vertices matrix should be an array.");
 
-        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(PyArray_FromObject(pyobj,NPY_DOUBLE,0,0));
-        if (array==nullptr)
+        PyArrayRef array(PyArray_FromObject(pyobj,NPY_DOUBLE,0,0));
+        if (static_cast<PyArrayObject*>(array)==nullptr)
             throw Error(SWIG_ValueError,"Vertices matrix cannot be converted into a matrix of double.");
 
         if (PyArray_NDIM(array)!=2 || PyArray_DIM(array,1)!=3)
@@ -358,35 +373,28 @@ namespace OpenMEEG {
         // cast (not a reinterpretation), so byte-swapped inputs are handled
         // correctly; it returns the same object (refcounted) when the input
         // already satisfies these requirements.
-        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(
-            PyArray_FROM_OTF(pyobj,NPY_INT64,NPY_ARRAY_IN_ARRAY | NPY_ARRAY_FORCECAST));
-        if (array==nullptr)
+        PyArrayRef array(PyArray_FROM_OTF(pyobj,NPY_INT64,NPY_ARRAY_IN_ARRAY | NPY_ARRAY_FORCECAST));
+        if (static_cast<PyArrayObject*>(array)==nullptr)
             throw Error(SWIG_ValueError,"Matrix of triangles cannot be converted to a matrix of int64.");
 
-        try {
-            mesh->reference_vertices(indmap);
+        mesh->reference_vertices(indmap);
 
-            auto get_vertex = [&](PyArrayObject* mat,const int i,const int j) {
-                const npy_int64 vi = *reinterpret_cast<npy_int64*>(PyArray_GETPTR2(mat,i,j));
-                if (vi<0 || static_cast<size_t>(vi)>=indmap.size()) {
-                    std::ostringstream oss;
-                    oss << "Vertex index " << vi << " in triangle " << i << " out of range";
-                    throw Error(SWIG_ValueError,oss.str().c_str());
-                }
-                return &(mesh->geometry().vertices().at(indmap.at(vi)));
-            };
-
-            for (int unsigned i=0; i<nbTriangles; ++i) {
-                Vertex* v1 = get_vertex(array,i,0);
-                Vertex* v2 = get_vertex(array,i,1);
-                Vertex* v3 = get_vertex(array,i,2);
-                mesh->triangles().push_back(Triangle(v1,v2,v3));
+        auto get_vertex = [&](PyArrayObject* mat,const int i,const int j) {
+            const npy_int64 vi = *reinterpret_cast<npy_int64*>(PyArray_GETPTR2(mat,i,j));
+            if (vi<0 || static_cast<size_t>(vi)>=indmap.size()) {
+                std::ostringstream oss;
+                oss << "Vertex index " << vi << " in triangle " << i << " out of range";
+                throw Error(SWIG_ValueError,oss.str().c_str());
             }
-        } catch (...) {
-            Py_DECREF(array);
-            throw;
+            return &(mesh->geometry().vertices().at(indmap.at(vi)));
+        };
+
+        for (int unsigned i=0; i<nbTriangles; ++i) {
+            Vertex* v1 = get_vertex(array,i,0);
+            Vertex* v2 = get_vertex(array,i,1);
+            Vertex* v3 = get_vertex(array,i,2);
+            mesh->triangles().push_back(Triangle(v1,v2,v3));
         }
-        Py_DECREF(array);
     }
 
     OpenMEEG::Matrix MonopoleSourceMat(const OpenMEEG::Geometry& geo,const OpenMEEG::Matrix& sources,const std::string& domain_name) {
@@ -435,6 +443,18 @@ namespace OpenMEEG {
         if ($1) delete $1;
     }
 
+    // Overload dispatch uses the typecheck typemaps, so without these the
+    // default (SWIG_ConvertPtr-based) checks reject arrays and every
+    // overloaded signature taking a Vector&/Matrix& becomes unreachable from
+    // numpy. Any array is accepted here -- shape/order/dtype validation stays
+    // in the 'in' typemaps above so that bad input keeps its specific error
+    // message instead of a generic "wrong number or type of arguments".
+    %typemap(typecheck,precedence=SWIG_TYPECHECK_POINTER) Vector& {
+        void* vptr = 0;
+        $1 = PyArray_Check($input) ||
+             SWIG_IsOK(SWIG_ConvertPtr($input,&vptr,SWIGTYPE_p_OpenMEEG__Vector,0));
+    }
+
     %typemap(in) Matrix& {
         try {
             $1 = new_OpenMEEG_Matrix($input);
@@ -449,10 +469,19 @@ namespace OpenMEEG {
         if ($1) delete $1;
     }
 
+    // Unlike Vector& above this is restricted to 2D arrays, so that a 1D array
+    // passed to an overload set containing both (e.g. Vector(Matrix&) vs the
+    // Vector(PyObject*) added by %extend) still reaches the PyObject* variant.
+    %typemap(typecheck,precedence=SWIG_TYPECHECK_POINTER) Matrix& {
+        void* vptr = 0;
+        $1 = (PyArray_Check($input) && PyArray_NDIM(reinterpret_cast<PyArrayObject*>($input))==2) ||
+             SWIG_IsOK(SWIG_ConvertPtr($input,&vptr,SWIGTYPE_p_OpenMEEG__Matrix,0));
+    }
+
     // C++ -> Python
 
     %typemap(out) unsigned& {
-        $result = PyInt_FromLong(*($1));
+        $result = PyLong_FromLong(*($1));
     }
 }
 
@@ -510,10 +539,36 @@ namespace OpenMEEG {
 %extend OpenMEEG::Vector {
     Vector(PyObject* pyobj) { return new_OpenMEEG_Vector(pyobj); }
 
+    static void Free(PyObject* capsule) {
+        SharedData* shared_data = reinterpret_cast<SharedData*>(PyCapsule_GetPointer(capsule,PyCapsule_GetName(capsule)));
+        delete shared_data;
+    }
+
     PyObject* array() {
         const npy_intp ndims = 1;
-        npy_intp ar_dim[] = { static_cast<npy_intp>(($self)->size()) };
-        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(PyArray_SimpleNewFromData(ndims,ar_dim,NPY_DOUBLE,static_cast<void*>(($self)->data())));
+        npy_intp dims[] = { static_cast<npy_intp>(($self)->size()) };
+
+        // The returned array is a live view, so it has to keep the data alive on its
+        // own: without a base object it dangles as soon as the Vector goes away (a
+        // plain `Vector(x).array()` was enough to read freed memory). Same shared_ptr
+        // + capsule scheme as Matrix::array() below.
+        SharedData* shared_data = new SharedData(($self)->get_shared_data_ptr());
+        void* data = static_cast<void*>(shared_data->get());
+        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(
+            PyArray_New(&PyArray_Type,ndims,dims,NPY_DOUBLE,NULL,data,0,
+                        NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_WRITEABLE,NULL));
+        if (array==nullptr) {
+            delete shared_data;
+            throw Error(SWIG_RuntimeError,"Cannot create numpy array from OpenMEEG vector.");
+        }
+
+        PyObject* capsule = PyCapsule_New(shared_data,"wrapped vector",static_cast<PyCapsule_Destructor>(&OpenMEEG_Vector_Free));
+        if (capsule==nullptr || PyArray_SetBaseObject(array,capsule)==-1) {
+            Py_XDECREF(capsule);
+            Py_DECREF(array);
+            throw Error(SWIG_RuntimeError,"Cannot create numpy array from OpenMEEG vector.");
+        }
+
         return PyArray_Return(array);
     }
 
@@ -540,21 +595,22 @@ namespace OpenMEEG {
     PyObject* array() {
 
         const npy_intp ndims = 2;
-        npy_intp* dims = new npy_intp[ndims];
-        dims[0] = ($self)->nlin();
-        dims[1] = ($self)->ncol();
+        npy_intp dims[] = { static_cast<npy_intp>(($self)->nlin()), static_cast<npy_intp>(($self)->ncol()) };
 
         SharedData* shared_data = new SharedData(($self)->get_shared_data_ptr());
         void* data = static_cast<void*>(shared_data->get());
-        PyObject* obj = PyArray_New(&PyArray_Type,ndims,dims,NPY_DOUBLE,NULL,
-                                    data,0,NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_OWNDATA,NULL);
-
-        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(obj);
-        if (array==nullptr)
+        // No NPY_ARRAY_OWNDATA: the capsule below owns the data, and PyArray_New drops
+        // the flag for caller-supplied data anyway.
+        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(
+            PyArray_New(&PyArray_Type,ndims,dims,NPY_DOUBLE,NULL,data,0,NPY_ARRAY_F_CONTIGUOUS,NULL));
+        if (array==nullptr) {
+            delete shared_data;
             throw Error(SWIG_RuntimeError,"Cannot create numpy array from OpenMEEG matrix.");
+        }
 
         PyObject* capsule = PyCapsule_New(shared_data,"wrapped matrix",static_cast<PyCapsule_Destructor>(&OpenMEEG_Matrix_Free));
-        if (PyArray_SetBaseObject(array,capsule)==-1) {
+        if (capsule==nullptr || PyArray_SetBaseObject(array,capsule)==-1) {
+            Py_XDECREF(capsule);
             Py_DECREF(array);
             throw Error(SWIG_RuntimeError,"Cannot create numpy array from OpenMEEG matrix.");
         }
@@ -576,15 +632,19 @@ namespace OpenMEEG {
 
     PyObject* array_flat() {
         const npy_intp ndims = 1;
-        npy_intp* dims = new npy_intp[ndims];
-        dims[0] = ($self)->size();
+        npy_intp dims[] = { static_cast<npy_intp>(($self)->size()) };
 
-        // make a copy of the data
-        double* data = new double[dims[0]];
-        double* start = (*($self)).data();
-        std::copy(start,start+dims[0],data);
-        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(PyArray_New(&PyArray_Type,ndims,dims,NPY_DOUBLE,NULL,
-                                                                            static_cast<void*>(data),0,NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_OWNDATA,NULL));
+        // Let numpy own the copy. Passing our own buffer with NPY_ARRAY_OWNDATA did
+        // not work: PyArray_New drops OWNDATA when it is handed existing data, so
+        // nothing ever freed it and every call leaked the whole array. (It could not
+        // have freed it correctly anyway -- the buffer came from new[], numpy frees.)
+        PyArrayObject* array = reinterpret_cast<PyArrayObject*>(PyArray_SimpleNew(ndims,dims,NPY_DOUBLE));
+        if (array==nullptr)
+            throw Error(SWIG_RuntimeError,"Cannot create numpy array from OpenMEEG symmetric matrix.");
+
+        const double* start = (*($self)).data();
+        std::copy(start,start+dims[0],static_cast<double*>(PyArray_DATA(array)));
+        PyArray_CLEARFLAGS(array,NPY_ARRAY_WRITEABLE);  // as before: this is a snapshot
         return PyArray_Return(array);
     }
 

--- a/wrapping/python/openmeeg/tests/test_free_threading.py
+++ b/wrapping/python/openmeeg/tests/test_free_threading.py
@@ -1,0 +1,54 @@
+import concurrent.futures as cf
+import os.path as op
+import sys
+import sysconfig
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import openmeeg as om
+from openmeeg._openmeeg_wrapper import Vector
+
+free_threaded = bool(sysconfig.get_config_var("Py_GIL_DISABLED"))
+
+
+@pytest.mark.skipif(not free_threaded, reason="requires a free-threaded build")
+def test_gil_not_reenabled():
+    """The extension must not make CPython fall back to enabling the GIL."""
+    # Importing a module without Py_MOD_GIL_NOT_USED re-enables the GIL process-wide
+    # rather than failing, so this is the only thing that catches a missing -nogil.
+    assert not sys._is_gil_enabled()
+
+
+@pytest.mark.skipif(not free_threaded, reason="requires a free-threaded build")
+def test_concurrent_geometry_load(data_path):
+    """Load geometries concurrently: gh-866 made the i/o registries safe for this."""
+    geom_file = op.join(data_path, "Head1", "Head1.geom")
+    cond_file = op.join(data_path, "Head1", "Head1.cond")
+
+    def load():
+        return om.read_geometry(geom_file, cond_file).nb_parameters()
+
+    with cf.ThreadPoolExecutor(max_workers=8) as pool:
+        results = [f.result() for f in [pool.submit(load) for _ in range(32)]]
+
+    assert len(set(results)) == 1, results
+    assert not sys._is_gil_enabled()
+
+
+@pytest.mark.skipif(not free_threaded, reason="requires a free-threaded build")
+def test_concurrent_typemap_conversion():
+    """Exercise the array typemaps from several threads at once."""
+    arrays = [np.full(64, float(i), order="F") for i in range(32)]
+
+    def roundtrip(arr):
+        # Vector.array() returns a view, so copy before the Vector goes away
+        vec = Vector(arr)
+        return vec.array().copy()
+
+    with cf.ThreadPoolExecutor(max_workers=8) as pool:
+        out = list(pool.map(roundtrip, arrays))
+
+    for got, want in zip(out, arrays):
+        assert_allclose(got, want)

--- a/wrapping/python/pyproject.toml
+++ b/wrapping/python/pyproject.toml
@@ -51,11 +51,10 @@ Documentation = "https://openmeeg.github.io"
 
 [build-system]
 requires = [
-    "setuptools>=68.0.0",
+    "setuptools>=70.1",  # integrated bdist_wheel, so no separate "wheel" dep
     "setuptools_scm>=6.2",
-    "wheel>=0.37.0",
     "numpy>=2.0.0rc1,<3",
-    "swig>=4.2",
+    "swig>=4.4",  # -nogil
 ]
 
 [tool.setuptools.packages.find]
@@ -73,7 +72,10 @@ local_scheme = "no-local-version"  # to allow TestPyPI uploads
 [tool.cibuildwheel]
 # pp310 should in principle work but in practice it doesn't
 skip = ["*-musllinux*"]
-build = ["cp310-*"]  # abi3
+# cp310 covers 3.10+ via abi3; the free-threaded build has no stable ABI (CPython
+# gh-111506) so it needs its own version-specific wheel.
+build = ["cp310-*", "cp314t-*"]
+enable = ["cpython-freethreading"]
 archs = "native"
 before-all = "bash {project}/build_tools/cibw_before_all.sh {project}"
 before-build = "pip install --only-binary=numpy \"numpy>=2,<3\""  # we don't want to build for any platform that NumPy does not provide wheels for

--- a/wrapping/python/pyproject.toml
+++ b/wrapping/python/pyproject.toml
@@ -75,7 +75,6 @@ skip = ["*-musllinux*"]
 # cp310 covers 3.10+ via abi3; the free-threaded build has no stable ABI (CPython
 # gh-111506) so it needs its own version-specific wheel.
 build = ["cp310-*", "cp314t-*"]
-enable = ["cpython-freethreading"]
 archs = "native"
 before-all = "bash {project}/build_tools/cibw_before_all.sh {project}"
 before-build = "pip install --only-binary=numpy \"numpy>=2,<3\""  # we don't want to build for any platform that NumPy does not provide wheels for

--- a/wrapping/python/pyproject.toml
+++ b/wrapping/python/pyproject.toml
@@ -88,7 +88,7 @@ environment-pass = ["CHECK_PORCELAIN", "RUNNER_OS"]  # useful to have RUNNER_OS 
 [tool.cibuildwheel.linux]
 repair-wheel-command = [
     "bash build_tools/cibw_repair_wheel_command_linux.sh {dest_dir} {wheel}",
-    "pipx run abi3audit --strict --report {wheel}",
+    "bash build_tools/cibw_abi3audit.sh {wheel}",
 ]
 # adapted from h5py
 manylinux-x86_64-image = "ghcr.io/h5py/manylinux_2_28_x86_64-hdf5"
@@ -105,7 +105,7 @@ CFLAGS = "-g1"  # from h5py
 [tool.cibuildwheel.macos]
 repair-wheel-command = [
     "bash build_tools/cibw_repair_wheel_command_macos.sh {delocate_archs} {dest_dir} {wheel}",
-    "pipx run abi3audit --strict --report {wheel}",
+    "bash build_tools/cibw_abi3audit.sh {wheel}",
 ]
 
 [tool.cibuildwheel.macos.environment]
@@ -131,7 +131,7 @@ OPENBLAS_INCLUDE = ""
 [tool.cibuildwheel.windows]
 repair-wheel-command = [
     "bash build_tools/cibw_repair_wheel_command_windows.sh {dest_dir} {wheel}",
-    "pipx run abi3audit --strict --report {wheel}",
+    "bash build_tools/cibw_abi3audit.sh {wheel}",
 ]
 
 [tool.cibuildwheel.windows.environment]

--- a/wrapping/python/setup.py
+++ b/wrapping/python/setup.py
@@ -7,30 +7,31 @@ from pathlib import Path
 import os
 import platform
 import sys
+import sysconfig
 
 from setuptools import setup, Extension  # noqa
 from setuptools.command import build_py
-from wheel.bdist_wheel import bdist_wheel
+from setuptools.dist import Distribution
 
 
-abi3 = (platform.python_implementation() == "CPython")
+# Oldest interpreter the stable ABI wheel targets, as a version hex and as the
+# matching wheel tag. The free-threaded build has no limited API at all --
+# Python.h #errors out if Py_LIMITED_API is defined alongside Py_GIL_DISABLED,
+# and setuptools raises on py_limited_api there too (CPython gh-111506).
+PY_LIMITED_API = "0x030A0000"
+PY_LIMITED_API_TAG = "cp310"
+abi3 = (
+    platform.python_implementation() == "CPython"
+    and not sysconfig.get_config_var("Py_GIL_DISABLED")
+)
 
 
-# Adapted from Apache-2.0 licensed code at:
-# https://github.com/joerick/python-abi3-package-sample/blob/main/setup.py
-
-class bdist_wheel_abi3(bdist_wheel):
-    def get_tag(self):
-        python, abi, plat = super().get_tag()
-        if abi3:
-            python, abi = "cp310", "abi3"
-        return python, abi, plat
-
-    # In cases where we don't SWIG, we still want to mark the wheel as impure
-    # (to make things nicer for app building)
-    def finalize_options(self):
-        super().finalize_options()
-        self.root_is_pure = False
+# CMake-driven builds hand us a prebuilt extension rather than an ext_module, so
+# setuptools would otherwise call the wheel pure -- which loses the platform tag
+# (nicer for app building) and suppresses the abi3 tag entirely.
+class BinaryDistribution(Distribution):
+    def has_ext_modules(self):
+        return True
 
 
 # Subclass the build command so that build_ext is called before build_py
@@ -44,7 +45,7 @@ if __name__ == "__main__":
     import numpy as np
 
     # SWIG
-    cmdclass = dict(build_py=BuildExtFirst, bdist_wheel=bdist_wheel_abi3)
+    cmdclass = dict(build_py=BuildExtFirst)
     ext_modules = []
     if os.getenv("OPENMEEG_USE_SWIG", "0").lower() in ("1", "true"):
         include_dirs = [np.get_include()]
@@ -55,11 +56,18 @@ if __name__ == "__main__":
             "_openmeeg_wrapper",
             "-interface",
             "_openmeeg",
-            # -O is problematic for abi3 because it enables "-fastproxy" which leads to
-            # linking errors. However, "-fastdispatch" is needed to create our
-            # typemaps, which seems like a bug (?) but doesn't create any ABI3 compat
-            # issues.
+            # "-O" without its other two flags: -fastproxy emits PyCFunctionObject and
+            # PyInstanceMethod_New, neither in the limited API, and -fvirtual measured
+            # ~6.5% slower here (it routes the 8 LinOp-derived size()/info() through a
+            # base-class ConvertPtr). -fastdispatch is purely an optimization now that
+            # the typecheck typemaps in _openmeeg.i make overload resolution work
+            # without it, so it can be dropped if upstream ever stops supporting it
+            # alongside abi3 (swig/swig#3089).
             "-fastdispatch",
+            # Declares Py_MOD_GIL_NOT_USED (SWIG >= 4.4, hence the build-system pin),
+            # which the i/o layer earned in gh-866. Without it CPython silently
+            # re-enables the GIL on free-threaded builds.
+            "-nogil",
             # Someday we could look at other options like:
             # "-extranative",  # Return extra native wrappers for C++ std containers wherever possible
             # "-castmode",  # Enable the casting mode, which allows implicit cast between types in Python
@@ -130,10 +138,9 @@ if __name__ == "__main__":
         #     /EHsc /Tpopenmeeg/openmeeg_wrap.cpp /Fobuild\temp.win-amd64-cpython-310\Release\openmeeg/openmeeg_wrap.obj
 
         define_macros = [("SWIG_PYTHON_SILENT_MEMLEAK", None)]
-        abi3_kwargs = dict()
         if abi3:
             define_macros += [
-                ("Py_LIMITED_API", "0x030A0000"),  # 3.10
+                ("Py_LIMITED_API", PY_LIMITED_API),
             ]
         swig_openmeeg = Extension(
             "openmeeg._openmeeg",
@@ -151,5 +158,9 @@ if __name__ == "__main__":
 
     setup(
         cmdclass=cmdclass,
+        distclass=BinaryDistribution,
         ext_modules=ext_modules,
+        options=(
+            {"bdist_wheel": {"py_limited_api": PY_LIMITED_API_TAG}} if abi3 else {}
+        ),
     )


### PR DESCRIPTION
1. In https://github.com/swig/swig/pull/3089#discussion_r1882976180 it was suggested that we fix our typemaps, this finally does it!
2. Get rid of the old Python 2 cruft
3. Modernizes our `setup.py` usage (bumping setuptools req in the process). Drafted and iterated with Claude Opus 5. The addition of the typemaps in principle allows us to put back `-fvirtual` (one of the three optimizations enabled by `-O`, and one of the two you can use in ABI3 mode), but in practice this only removes 8 of the 1000+ wrappers, and those become slower (so not really an optimization for us)
4. Add Python 3.14t free-threaded wheels (and ensure we don't require GIL)
5. Fix minor data-ownership bugs in `Vector::array()` and related functions that forced end users to use `.copy()` to prevent junk data

Closes #874

@papadop I think we should maybe cut a release after this WDYT? Also, this ended up being a bit longer than I anticipated as digging into the free-threaded stuff and adding tests I hit a speedbump with `Vector::array()`, which I fixed... and then that caused me (and Claude Opus 5) to look more into all the `ndarray` refs and fix/unify them. Happy to split it out into several PRs if that helps review!