### PR TITLE
Fix memory leaks in Python interface

### DIFF
--- a/wrapping/python/CMakeLists.txt
+++ b/wrapping/python/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 
 list(APPEND CMAKE_SWIG_FLAGS -v -fastdispatch)
 set(SWIG_MODULE_openmeeg_EXTRA_DEPS openmeeg/numpy.i ${SWIG_MODULE_openmeeg_EXTRA_DEPS})
-set_source_files_properties(openmeeg/_openmeeg.i PROPERTIES CPLUSPLUS ON GENERATED_COMPILE_DEFINITIONS SWIG_PYTHON_SILENT_MEMLEAK SWIG_MODULE_NAME _openmeeg_wrapper)
+set_source_files_properties(openmeeg/_openmeeg.i PROPERTIES CPLUSPLUS ON SWIG_MODULE_NAME _openmeeg_wrapper)
 # This puts _openmeeg.py in openmeeg/
 swig_add_library(${SWIG_TARGET_NAME} LANGUAGE python OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/openmeeg SOURCES openmeeg/_openmeeg.i)
 if (PYTHON_USE_SABI)

--- a/wrapping/python/openmeeg/_openmeeg.i
+++ b/wrapping/python/openmeeg/_openmeeg.i
@@ -40,8 +40,6 @@
     }
 }
 
-#define SWIG_PYTHON_SILENT_MEMLEAK
-
 #ifdef SWIGWIN
 %include <windows.i>
 #endif
@@ -54,12 +52,15 @@
 
 %include <std_string.i>
 %include <std_vector.i>
+%include <std_map.i>
 
 %{
     #include <logger.h>
     #include <vect3.h>
     #include <vertex.h>
     #include <triangle.h>
+    #include <range.h>
+    #include <ranges.h>
     #include <linop.h>
     #include <vector.h>
     #include <matrix.h>
@@ -143,6 +144,12 @@ namespace std {
     %template(vector_simple_dom) vector<OpenMEEG::SimpleDomain>;
     %template(vector_domain) vector<OpenMEEG::Domain>;
     %template(vector_oriented_mesh) vector<OpenMEEG::OrientedMesh>;
+
+    // OpenMEEG::IndexMap. Without this swig has no destructor for the type, so every
+    // IndexMap returned by Geometry::add_vertices() was heap-allocated and never freed
+    // (~48 bytes per vertex, per call). Every wrapped type needs one, which is why
+    // SWIG_PYTHON_SILENT_MEMLEAK is no longer defined -- it hid exactly this.
+    %template(IndexMap) map<unsigned,unsigned>;
 }
 
 namespace OpenMEEG {
@@ -669,6 +676,14 @@ namespace OpenMEEG {
 %include <vect3.h>
 %include <vertex.h>
 %include <triangle.h>
+// Mesh::triangles_range()/vertices_ranges() return these by value, so swig needs the
+// definitions to generate destructors -- otherwise every call leaks (same as IndexMap).
+// The unqualified %ignore operator<< above does not reach into OpenMEEG::maths, and
+// wrapping it there collides with the existing __lshift__ dispatcher.
+%ignore OpenMEEG::maths::operator<<;
+%include <range.h>
+%template(vector_range) std::vector<OpenMEEG::maths::Range>;
+%include <ranges.h>
 %include <linop.h>
 %include <vector.h>
 %include <matrix.h>

--- a/wrapping/python/setup.py
+++ b/wrapping/python/setup.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
         #     /c /nologo /O2 /W3 /GL /DNDEBUG /MD
         #     /EHsc /Tpopenmeeg/openmeeg_wrap.cpp /Fobuild\temp.win-amd64-cpython-310\Release\openmeeg/openmeeg_wrap.obj
 
-        define_macros = [("SWIG_PYTHON_SILENT_MEMLEAK", None)]
+        define_macros = []
         abi3_kwargs = dict()
         if abi3:
             define_macros += [


### PR DESCRIPTION
I found this one by debugging a bit... but `SWIG_PYTHON_SILENT_MEMLEAK` would have found it if we didn't have it enabled. So remove it, and fix the leak call sites.

This one is pretty straightforward so I'll mark for merge-when-green