### PR TITLE
Use more natural C++ methods

### DIFF
--- a/OpenMEEG/include/gain.h
+++ b/OpenMEEG/include/gain.h
@@ -38,9 +38,7 @@ namespace OpenMEEG {
         for (int i=0; i<static_cast<int>(S.nlin()); ++i) {
         #endif
             e.Run([&](){
-                Vector vtemp(H.nlin());
-                GMRes(H,M,vtemp,S.getlin(i),1000,1e-7,H.nlin()); // max number of iteration=1000, and precision=1e-7 (1e-5 for faster resolution)
-                res.setlin(i,vtemp);
+                res.row(i) = GMRes(H,M,S.row(i),1000,1e-7,H.nlin()).first; // max number of iteration=1000, and precision=1e-7 (1e-5 for faster resolution)
                 #pragma omp critical
                 PROGRESSBAR(i,S.nlin());
             });
@@ -84,7 +82,7 @@ namespace OpenMEEG {
             const Matrix& Hinv = linsolve(HeadMat,Head2EEGMat);
             ProgressBar pb(ncol());
             for (unsigned i=0; i<ncol(); ++i,++pb)
-                setcol(i,Hinv*SourceMatrix<Dipole>(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").getcol(0)); // TODO ugly
+                column(i) = Hinv*SourceMatrix<Dipole>(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").column(0);
         }
     };
 
@@ -99,7 +97,7 @@ namespace OpenMEEG {
             const Matrix& Hinv = linsolve(HeadMat,Head2MEGMat);
             ProgressBar pb(ncol());
             for (unsigned i=0; i<ncol(); ++i,++pb)
-                setcol(i,Hinv*SourceMatrix<Dipole>(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").getcol(0)+Source2MEGMat.getcol(i)); // TODO ugly
+                column(i) = Hinv*SourceMatrix<Dipole>(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").column(0)+Source2MEGMat.column(i);
         }
     };
 
@@ -110,17 +108,17 @@ namespace OpenMEEG {
         {
             Matrix RHS(Head2EEGMat.nlin()+Head2MEGMat.nlin(),HeadMat.nlin());
             for (unsigned i=0; i<Head2EEGMat.nlin(); ++i)
-                RHS.setlin(i,Head2EEGMat.getlin(i));
+                RHS.row(i) = Head2EEGMat.row(i);
             for (unsigned i=0; i<Head2MEGMat.nlin(); ++i)
-                RHS.setlin(i+Head2EEGMat.nlin(),Head2MEGMat.getlin(i));
+                RHS.row(i+Head2EEGMat.nlin()) = Head2MEGMat.row(i);
 
             const Matrix& Hinv = linsolve(HeadMat,RHS);
 
             ProgressBar pb(dipoles.nlin());
             for (unsigned i=0; i<dipoles.nlin(); ++i,++pb) {
-                const Vector& dsm = SourceMatrix<Dipole>(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").getcol(0); // TODO ugly
-                EEGleadfield.setcol(i,Hinv.submat(0,Head2EEGMat.nlin(),0,HeadMat.nlin())*dsm);
-                MEGleadfield.setcol(i,Hinv.submat(Head2EEGMat.nlin(),Head2MEGMat.nlin(),0,HeadMat.nlin())*dsm+Source2MEGMat.getcol(i));
+                const Vector& dsm = SourceMatrix<Dipole>(geo,dipoles.submat(i,1,0,dipoles.ncol()),"").column(0); // TODO ugly
+                EEGleadfield.column(i) = Hinv.submat(0,Head2EEGMat.nlin(),0,HeadMat.nlin())*dsm;
+                MEGleadfield.column(i) = Hinv.submat(Head2EEGMat.nlin(),Head2MEGMat.nlin(),0,HeadMat.nlin())*dsm+Source2MEGMat.column(i);
             }
         }
 

--- a/OpenMEEG/include/gmres.h
+++ b/OpenMEEG/include/gmres.h
@@ -74,15 +74,17 @@ namespace OpenMEEG {
             x += v[j]*y(j);
     }
 
-    // Code taken from http://www.netlib.org/templates/cpp/gmres.h and modified
+    // Code taken from http://www.netlib.org/templates/cpp/gmres.h and modified.
 
     template <typename T,typename P> // T should be a linear operator, and P a preconditionner
-    unsigned GMRes(const T& A,const P& M,Vector &x,const Vector& b,int max_iter,double tol,unsigned m) {
+    std::pair<Vector,bool>
+    GMRes(const T& A,const P& M,const Vector& b,int max_iter,double tol,const unsigned m) {
 
         // m is the size of the Krylov subspace, if m<A.nlin(), it is a restarted GMRes (for saving memory)
 
         Matrix H(m+1,m);
-        x.set(0.0);
+        Vector x(A.ncol());
+        x = 0.0;
 
         Vector r = M(b-A*x); // M.solve(b-A*x);
         double beta = r.norm();
@@ -91,19 +93,19 @@ namespace OpenMEEG {
         if (normb==0.0)
             normb = 1;
 
-        double resid;
-        if ((resid = r.norm()/normb)<=tol) {
+        if ((double resid = r.norm()/normb)<=tol) {
             tol = resid;
             max_iter = 0;
-            return 0;
+            return { x, true };
         }
 
-        Vector* v = new Vector[m+1];
+        Vector v[m+1];
         Vector s(m+1),cs(m+1),sn(m+1),w;
 
+        double resid;
         for (int j=1; j<=max_iter; ) {
             v[0] = r*(1.0/beta);
-            s.set(0.0);
+            s = 0.0;
             s(0) = beta;
 
             for (int i=0; i<m && j<=max_iter; ++i, ++j) {
@@ -126,8 +128,7 @@ namespace OpenMEEG {
                     Update(x,i,H,s,v);
                     tol = resid;
                     max_iter = j;
-                    delete [] v;
-                    return 0;
+                    return { x, true };
                 }
             }
             Update(x,i-1,H,s,v);
@@ -136,13 +137,11 @@ namespace OpenMEEG {
             if ((resid = beta/normb)<tol) {
                 tol = resid;
                 max_iter = j;
-                delete [] v;
-                return 0;
+                return { x, true };
             }
         }
 
         tol = resid;
-        delete [] v;
-        return 1;
+        return { x , false };
     }
 }

--- a/OpenMEEG/include/operators.h
+++ b/OpenMEEG/include/operators.h
@@ -30,10 +30,10 @@ namespace OpenMEEG {
     void operatorFerguson(const Vect3&,const Mesh&,Matrix&,const unsigned&,const double);
 
     template <typename Source>
-    void operatorPotential(const Source& source,const Mesh& m,Vector& rhs,const double coeff,const Integrator& integrator);
+    Vector operatorPotential(const unsigned size,const Source& source,const Mesh& m,const Integrator& integrator);
 
     template <typename Source>
-    void operatorPotentialDerivative(const Source& source,const Mesh& m,Vector& rhs,const double coeff,const Integrator& integrator);
+    Vector operatorPotentialDerivative(const unsigned size,const Source& source,const Mesh& m,const Integrator& integrator);
 
     namespace Details {
 
@@ -492,7 +492,7 @@ namespace OpenMEEG {
 
         // SymMatrix is initialized at once, and there is nothing to for blockwise matrix.
 
-        static void init(SymMatrix& matrix) { matrix.set(0.0); }
+        static void init(SymMatrix& matrix) { matrix = 0.0; }
         void set_blocks(SymMatrix&) const   { }
 
         // SymmetricBlockMatrix is initialized blockwise.

--- a/OpenMEEG/include/sensors.h
+++ b/OpenMEEG/include/sensors.h
@@ -87,7 +87,7 @@ namespace OpenMEEG {
         Sensors(const Matrix& positions,const Geometry& g):
             m_nb(positions.nlin()),m_positions(positions),m_radii(m_nb),geometry(&g)
         {
-            m_radii.set(0.0);
+            m_radii = 0.0;
             findInjectionTriangles();
         }
 
@@ -146,11 +146,11 @@ namespace OpenMEEG {
 
         /// Return the position (3D point) of the integration point idx.
 
-        Vector getPosition(const size_t idx) const { return m_positions.getlin(idx); }
+        Vector getPosition(const size_t idx) const { return m_positions.row(idx); }
 
         /// Return the orientations (3D point) of the integration point idx.
 
-        Vector getOrientation(const size_t idx) const { return m_orientations.getlin(idx); }
+        Vector getOrientation(const size_t idx) const { return m_orientations.row(idx); }
 
         /// Return the name of the idx_th sensor.
 
@@ -161,11 +161,11 @@ namespace OpenMEEG {
 
         /// Set the position (3D point) of the integration point i.
 
-        void setPosition(const size_t idx,const Vector& pos) { return m_positions.setlin(idx,pos); }
+        void setPosition(const size_t idx,const Vector& pos) { m_positions.row(idx) = pos; }
 
         /// Set the orientation (3D point) of the integration point i.
 
-        void setOrientation(const size_t idx,const Vector& orient) { return m_orientations.setlin(idx,orient); }
+        void setOrientation(const size_t idx,const Vector& orient) { m_orientations.row(idx) = orient; }
 
         bool hasSensor(const std::string& name) const {
             return std::find(m_names.begin(),m_names.end(),name)!=m_names.end();

--- a/OpenMEEG/src/assembleHeadMat.cpp
+++ b/OpenMEEG/src/assembleHeadMat.cpp
@@ -149,17 +149,17 @@ namespace OpenMEEG {
         log_stream(INFORMATION) << " with " << Nl << " lines" << std::endl;
 
         Matrix matrix = Matrix(Nl,symmatrix.ncol());
-        matrix.set(0.0);
+        matrix = 0.0;
         unsigned iNl = 0;
         for (const auto& mesh : geo.meshes())
             if (mesh!=cortex) {
                 log_stream(INFORMATION) << "Processing mesh " << mesh.name() << " : vertices";
                 for (const auto& vertex : mesh.vertices())
-                    matrix.setlin(iNl++,symmatrix.getlin(vertex->index()));
+                    matrix.row(iNl++) = symmatrix.row(vertex->index());
                 if (!mesh.current_barrier()) {
                     log_stream(INFORMATION) << " : triangles";
                     for (const auto& triangle : mesh.triangles())
-                        matrix.setlin(iNl++,symmatrix.getlin(triangle.index()));
+                        matrix.row(iNl++) = symmatrix.row(triangle.index());
                 }
                 log_stream(INFORMATION) << " done." << std::endl;
             }
@@ -207,7 +207,7 @@ namespace OpenMEEG {
 
         const unsigned Nc = geo.nb_parameters()-geo.nb_current_barrier_triangles();
         SymMatrix RR(Nc,Nc);
-        RR.set(0.0);
+        RR = 0.0;
         for (const auto& mesh : geo.meshes())
             mesh.gradient_norm2(RR);
 
@@ -220,7 +220,6 @@ namespace OpenMEEG {
         double beta1  = beta;
         if (alpha1<0) { // try an automatic method... TODO find better estimation
             const double nRR_v = RR.submat(0,geo.vertices().size(),0,geo.vertices().size()).frobenius_norm();
-            alphas.set(0.);
             alpha1 = MM.frobenius_norm()/(1.e3*nRR_v);
             beta1  = alpha1*50000.;
             log_stream(INFORMATION) << "AUTOMATIC alphas = " << alpha1 << "\tbeta = " << beta1 << std::endl;
@@ -304,7 +303,7 @@ namespace OpenMEEG {
         // Get the gradient of P1&P0 elements on the meshes.
 
         SymMatrix G(Nc);
-        G.set(0.0);
+        G = 0.0;
         for (const auto& mesh : geo.meshes())
             mesh.gradient_norm2(G);
 
@@ -333,7 +332,7 @@ namespace OpenMEEG {
             const Vect3 point(points(i,0),points(i,1),points(i,2));
             const Domain& domain = geo.domain(point);
             if (domain.conductivity()==0.0) {
-                log_stream(INFORMATION) << " Surf2Vol: Point [ " << points.getlin(i) << "]"
+                log_stream(INFORMATION) << " Surf2Vol: Point [ " << points.row(i) << "]"
                                         << " is inside a non-conductive domain. Point is dropped." << std::endl;
             } else {
                 m_points[&domain].push_back(Vertex(point,index++));
@@ -345,7 +344,7 @@ namespace OpenMEEG {
         const unsigned size = index; // total number of inside points
 
         Matrix mat(size,geo.nb_parameters()-geo.nb_current_barrier_triangles());
-        mat.set(0.0);
+        mat = 0.0;
 
         for (const auto& [domainptr,pts] : m_points) {
             for (const auto& boundary : domainptr->boundaries())

--- a/OpenMEEG/src/assembleSensors.cpp
+++ b/OpenMEEG/src/assembleSensors.cpp
@@ -74,12 +74,12 @@ namespace OpenMEEG {
         unsigned p0_p1_size = geo.nb_parameters()-geo.nb_current_barrier_triangles();
 
         Matrix FergusonMat(3*nbIntegrationPoints,geo.vertices().size());
-        FergusonMat.set(0.0);
+        FergusonMat = 0.0;
 
         assemble_ferguson(geo,FergusonMat,positions);
 
         Matrix mat(nbIntegrationPoints,p0_p1_size);
-        mat.set(0.0);
+        mat = 0.0;
 
         ProgressBar pb(nbIntegrationPoints);
         for (unsigned i=0; i<nbIntegrationPoints; ++i,++pb) {
@@ -106,13 +106,13 @@ namespace OpenMEEG {
         const unsigned nsquids     = positions.nlin();
 
         Matrix mat(nsquids,sources_mesh.vertices().size());
-        mat.set(0.0);
+        mat = 0.0;
 
         ProgressBar pb(nsquids);
         for (unsigned i=0; i<nsquids; ++i,++pb) {
             Vect3 p(positions(i,0),positions(i,1),positions(i,2));
             Matrix FergusonMat(3,mat.ncol());
-            FergusonMat.set(0.0);
+            FergusonMat = 0.0;
             operatorFerguson(p,sources_mesh,FergusonMat,0,1.);
             for (unsigned j=0;j<mat.ncol();++j) {
                 const Vect3 fergusonField(FergusonMat(0,j),FergusonMat(1,j),FergusonMat(2,j));

--- a/OpenMEEG/src/assembleSourceMat.cpp
+++ b/OpenMEEG/src/assembleSourceMat.cpp
@@ -41,7 +41,7 @@ namespace OpenMEEG {
                                 << std::endl;
 
         Matrix mat(geo.nb_parameters()-geo.nb_current_barrier_triangles(),source_mesh.vertices().size());
-        mat.set(0.0);
+        mat = 0.0;
 
         const double L  = -1.0/domain.conductivity();
         for (const auto& boundary : domain.boundaries()) {
@@ -70,10 +70,9 @@ namespace OpenMEEG {
         const size_t n_sources = sources.nlin();
 
         Matrix rhs(size,n_sources);
-        rhs.set(0.0);
+        rhs = 0.0;
 
         ProgressBar pb(n_sources);
-        Vector rhs_col(rhs.nlin());
         for (unsigned s=0; s<n_sources; ++s,++pb) {
             const Source source(s,sources);
             const Domain domain = (domain_name=="") ? geo.domain(source.position()) : geo.domain(domain_name);
@@ -82,22 +81,20 @@ namespace OpenMEEG {
 
             const double cond = domain.conductivity();
             if (cond!=0.0) {
-                rhs_col.set(0.0);
                 for (const auto& boundary : domain.boundaries()) {
                     const double factorD = (boundary.inside()) ? -K : K;
                     for (const auto& oriented_mesh : boundary.interface().oriented_meshes()) {
                         //  Process the mesh.
                         const double coeffD = factorD*oriented_mesh.orientation();
                         const Mesh&  mesh   = oriented_mesh.mesh();
-                        operatorPotentialDerivative(source,mesh,rhs_col,coeffD,integrator);
+                        rhs.column(s) += coeffD*operatorPotentialDerivative(size,source,mesh,integrator);
 
                         if (!oriented_mesh.mesh().current_barrier()) {
                             const double coeff = coeffD/cond;;
-                            operatorPotential(source,mesh,rhs_col,coeff,integrator);
+                            rhs.column(s) += coeff*operatorPotential(size,source,mesh,integrator);
                         }
                     }
                 }
-                rhs.setcol(s,rhs_col);
             }
         }
         return rhs;
@@ -114,7 +111,7 @@ namespace OpenMEEG {
         // rhs = [0 ... 0  -D*_23  sigma_3^(-1)S_23  -I_33/2.+D*_33]
 
         SymMatrix transmat(geo.nb_parameters());
-        transmat.set(0.0);
+        transmat = 0.0;
 
         // This is an overkill. Can we limit the computation only to injection triangles ?
         // We use only the few lines that correspond to injection triangles.
@@ -138,7 +135,7 @@ namespace OpenMEEG {
 
         const size_t n_sensors = electrodes.getNumberOfSensors();
         Matrix mat(geo.nb_parameters()-geo.nb_current_barrier_triangles(),n_sensors);
-        mat.set(0.0);
+        mat = 0.0;
 
         for (size_t ielec=0; ielec<n_sensors; ++ielec)
             for (const auto& triangle : electrodes.getInjectionTriangles(ielec)) {
@@ -164,13 +161,13 @@ namespace OpenMEEG {
                 points_domain.push_back(&domain);
                 pts.push_back(point);
             } else {
-                std::cerr << " DipSource2InternalPot: Point [ " << points.getlin(i)
+                std::cerr << " DipSource2InternalPot: Point [ " << points.row(i)
                           << "] is outside the head. Point is dropped." << std::endl;
             }
         }
 
         Matrix mat(pts.size(),dipoles.nlin());
-        mat.set(0.0);
+        mat = 0.0;
 
         for (unsigned iDIP=0; iDIP<dipoles.nlin(); ++iDIP) {
             const Dipole dipole(iDIP,dipoles);

--- a/OpenMEEG/src/mesh.cpp
+++ b/OpenMEEG/src/mesh.cpp
@@ -221,7 +221,7 @@ namespace OpenMEEG {
             }
 
         for (const auto& vertex : vertices())
-            A(vertex->index(),vertex->index()) = -A.getlin(vertex->index()).sum();
+            A(vertex->index(),vertex->index()) = -A.row(vertex->index()).sum();
     }
 
     bool Mesh::has_self_intersection() const {

--- a/OpenMEEG/src/operators.cpp
+++ b/OpenMEEG/src/operators.cpp
@@ -38,7 +38,9 @@ namespace OpenMEEG {
     }
 
     template <typename Source>
-    void operatorPotential(const Source& source,const Mesh& m,Vector& rhs,const double coeff,const Integrator& integrator) {
+    Vector operatorPotential(const unsigned size,const Source& source,const Mesh& m,const Integrator& integrator) {
+        Vector res(size);
+        res = 0.0;
         const auto& potential = [&source](const Vect3& r) { return source.potential(r); };
         ThreadException e;
         #pragma omp parallel for
@@ -52,15 +54,17 @@ namespace OpenMEEG {
             const Triangle& triangle = *(m.triangles().begin()+i);
         #endif
             e.run([&](){
-                const double d = integrator.integrate(potential,triangle);
-                rhs(triangle.index()) += d*coeff;
+                res(triangle.index()) += integrator.integrate(potential,triangle);
             });
         }
         e.rethrow();
+        return res;
     }
 
     template <typename Source>
-    void operatorPotentialDerivative(const Source& source,const Mesh& m,Vector& rhs,const double coeff,const Integrator& integrator) {
+    Vector operatorPotentialDerivative(const unsigned size,const Source& source,const Mesh& m,const Integrator& integrator) {
+        Vector res(size);
+        res = 0.0;
         ThreadException e;
         #pragma omp parallel for
         #if defined NO_OPENMP || defined OPENMP_RANGEFOR
@@ -78,17 +82,18 @@ namespace OpenMEEG {
                 const Vect3& v = integrator.integrate(pot_derivative,triangle);
 
                 for (unsigned j=0; j<3; ++j) {
-                    double& r = rhs(triangle.vertex(j).index());
+                    double& r = res(triangle.vertex(j).index());
                     #pragma omp atomic
-                    r += v(j)*coeff;
+                    r += v(j);
                 }
             });
         }
         e.rethrow();
+        return res;
     }
 
-    template void operatorPotential<Monopole>(const Monopole& source,const Mesh& m,Vector& rhs,const double coeff,const Integrator& integrator);
-    template void operatorPotential<Dipole>(const Dipole& source,const Mesh& m,Vector& rhs,const double coeff,const Integrator& integrator);
-    template void operatorPotentialDerivative<Monopole>(const Monopole& source,const Mesh& m,Vector& rhs,const double coeff,const Integrator& integrator);
-    template void operatorPotentialDerivative<Dipole>(const Dipole& source,const Mesh& m,Vector& rhs,const double coeff,const Integrator& integrator);
+    template Vector operatorPotential<Monopole>(const unsigned size,const Monopole& source,const Mesh& m,const Integrator& integrator);
+    template Vector operatorPotential<Dipole>(const unsigned size,const Dipole& source,const Mesh& m,const Integrator& integrator);
+    template Vector operatorPotentialDerivative<Monopole>(const unsigned size,const Monopole& source,const Mesh& m,const Integrator& integrator);
+    template Vector operatorPotentialDerivative<Dipole>(const unsigned size,const Dipole& source,const Mesh& m,const Integrator& integrator);
 }

--- a/OpenMEEG/src/sensors.cpp
+++ b/OpenMEEG/src/sensors.cpp
@@ -92,7 +92,7 @@ namespace OpenMEEG {
             }
             Vector v(ncol);
             iss >> v;
-            mat.setlin(i,v);
+            mat.row(i) = v;
         }
 
         // Initialize private members
@@ -102,20 +102,20 @@ namespace OpenMEEG {
         // weights
         if (geometry!=nullptr) { // EIT
             if (ncol==4) { // if radii were specified
-                m_radii = mat.getcol(mat.ncol()-1);
+                m_radii = mat.column(mat.ncol()-1);
             } else {
                 m_radii = Vector(nlin);
-                m_radii.set(0.0);
+                m_radii = 0.0;
             }
             // find triangles on which to inject the currents and compute weights
             findInjectionTriangles();
         } else if (ncol==4) {
             throw OpenMEEG::GenericError("Sensors:: please specify at constructor stage the geometry on which to apply the spatially extended EIT sensors.");
         } else if (ncol==7) { // MEG
-            m_weights = mat.getcol(mat.ncol()-1);
+            m_weights = mat.column(mat.ncol()-1);
         } else { // Others
             m_weights = Vector(nlin);
-            m_weights.set(1.);
+            m_weights = 1.0;
         }
         m_pointSensorIdx = std::vector<size_t>(nlin);
 
@@ -148,10 +148,10 @@ namespace OpenMEEG {
 
             if (hasNames())
                 outfile << m_names[m_pointSensorIdx[i]] << " ";
-            outfile << m_positions.getlin(i) << " ";
+            outfile << m_positions.row(i) << " ";
 
             if (hasOrientations())
-                outfile << m_orientations.getlin(i) << " ";
+                outfile << m_orientations.row(i) << " ";
 
             // if has weights other than 1
 
@@ -167,7 +167,7 @@ namespace OpenMEEG {
     void Sensors::findInjectionTriangles() {
         om_error(geometry!=NULL);
         m_weights = Vector(m_positions.nlin());
-        m_weights.set(1.0);
+        m_weights = 1.0;
         Strings ci_mesh_names;
         std::vector<size_t> ci_triangles; // Count of the number of points that have been mapped to each mesh.
 

--- a/OpenMEEGMaths/include/fast_sparse_matrix.h
+++ b/OpenMEEGMaths/include/fast_sparse_matrix.h
@@ -109,7 +109,7 @@ namespace OpenMEEG {
 
         Vector operator*(const Vector& v) const {
             Vector result(m_nlin);
-            result.set(0.0);
+            result = 0.0;
             double* pt_result = result.data();
             double* pt_vect   = v.data();
 

--- a/OpenMEEGMaths/include/matrix.h
+++ b/OpenMEEGMaths/include/matrix.h
@@ -22,6 +22,11 @@ namespace OpenMEEG {
     class SymMatrix;
     class Vector;
 
+    namespace Details {
+        class ColReference;
+        class RowReference;
+    }
+
     /// \brief  Matrix class
     /// Matrix class
 
@@ -94,13 +99,41 @@ namespace OpenMEEG {
         Matrix submat(const Index istart,const Index isize,const Index jstart,const Index jsize) const;
         void   insertmat(const Index istart,const Index jstart,const Matrix& B);
 
-        Vector getcol(const Index j) const;
-        void   setcol(const Index j,const Vector& v);
+        Details::RowReference row(const Index j);
+        Details::ColReference column(const Index j);
 
-        Vector getlin(const Index i) const;
-        void   setlin(const Index i,const Vector& v);
+        void operator=(const double d) {
+            const size_t sz = size();
+            for (size_t i=0; i<sz; i++)
+                data()[i] = d;
+        }
 
-        const Matrix& set(const double d);
+        Vector row(const Index i) const {
+            om_assert(i<nlin());
+            Vector res(ncol());
+        #ifdef HAVE_BLAS
+            const BLAS_INT M = sizet_to_int(nlin());
+            const BLAS_INT N = sizet_to_int(ncol());
+            BLAS(dcopy,DCOPY)(N,data()+i,M,res.data(),1);
+        #else
+            for (Index j=0; j<ncol(); ++j)
+                res(j) = (*this)(i,j);
+        #endif
+            return res;
+        }
+
+        Vector column(const Index j) const {
+            om_assert(j<ncol( ));
+            Vector res(nlin());
+        #ifdef HAVE_BLAS
+            const BLAS_INT M = sizet_to_int(nlin());
+            BLAS(dcopy,DCOPY)(M,data()+nlin()*j,1,res.data(),1);
+        #else
+            for (Index i=0; i<nlin(); ++i)
+                res(i) = (*this)(i,j);
+        #endif
+            return res;
+        }
 
         Matrix operator*(const Matrix& B) const;
         Matrix operator*(const SymMatrix& B) const;
@@ -161,6 +194,82 @@ namespace OpenMEEG {
         friend class SymMatrix;
     };
 
+    namespace Details {
+        
+        class ColReference {
+        public:
+
+            ColReference(Matrix& M,const Index ind): mat(M),colind(ind) { om_assert(ind<mat.ncol()); }
+
+            operator Vector() {
+                Vector res(mat.nlin());
+                for (unsigned i=0; i<mat.nlin(); ++i)
+                    res(i) = mat(i,colind);
+                return res;
+            }
+
+            void operator=(const Vector& V) {
+                om_assert(V.size()==mat.nlin());
+                for (unsigned i=0; i<V.size(); ++i)
+                    mat(i,colind) = V(i);
+            }
+
+            void operator+=(const Vector& V) {
+                om_assert(V.size()==mat.nlin());
+                for (unsigned i=0; i<V.size(); ++i)
+                    mat(i,colind) += V(i);
+            }
+
+            void operator+=(const double d) {
+                for (unsigned i=0; i<mat.nlin(); ++i)
+                    mat(i,colind) += d;
+            }
+
+        private:
+
+            Matrix& mat;
+            Index   colind;
+        };
+        
+        class RowReference {
+        public:
+
+            RowReference(Matrix& M,const Index ind): mat(M),rowind(ind) { om_assert(ind<mat.nlin()); }
+
+            operator Vector() {
+                Vector res(mat.ncol());
+                for (unsigned i=0; i<mat.ncol(); ++i)
+                    res(i) = mat(rowind,i);
+                return res;
+            }
+
+            void operator=(const Vector& V) {
+                om_assert(V.size()==mat.ncol());
+                for (unsigned i=0; i<V.size(); ++i)
+                    mat(rowind,i) = V(i);
+            }
+
+            void operator+=(const Vector& V) {
+                om_assert(V.size()==mat.ncol());
+                for (unsigned i=0; i<V.size(); ++i)
+                    mat(rowind,i) += V(i);
+            }
+
+            void operator+=(const double d) {
+                for (unsigned i=0; i<mat.ncol(); ++i)
+                    mat(rowind,i) += d;
+            }
+
+        private:
+
+            Matrix& mat;
+            Index   rowind;
+        };
+    }
+
+    inline Details::ColReference Matrix::column(const Index i) { return Details::ColReference(*this,i); }
+    inline Details::RowReference Matrix::row(const Index i)    { return Details::RowReference(*this,i); }
+
     inline std::ostream& operator<<(std::ostream& os,const Matrix& M) {
         for (unsigned i=0; i<M.nlin(); ++i) {
             for (unsigned j=0; j<M.ncol(); ++j)
@@ -196,7 +305,7 @@ namespace OpenMEEG {
         const BLAS_INT N = sizet_to_int(ncol());
         DGEMV(CblasNoTrans,M,N,1.0,data(),M,v.data(),1,0.0,res.data(),1);
     #else
-        res.set(0.0);
+        res = 0.0;
         for (Index j=0; j<ncol(); ++j)
             for (Index i=0; i<nlin(); ++i)
                 res(i) += (*this)(i,j)*v(j);
@@ -228,57 +337,6 @@ namespace OpenMEEG {
         for (Index j=0; j<B.ncol(); ++j)
             for (Index i=0; i<B.nlin(); ++i)
                 (*this)(istart+i,jstart+j) = B(i,j);
-    }
-
-    inline Vector Matrix::getcol(const Index j) const {
-        om_assert(j<ncol( ));
-        Vector res(nlin());
-    #ifdef HAVE_BLAS
-        const BLAS_INT M = sizet_to_int(nlin());
-        BLAS(dcopy,DCOPY)(M,data()+nlin()*j,1,res.data(),1);
-    #else
-        for (Index i=0; i<nlin(); ++i)
-            res(i) = (*this)(i,j);
-    #endif
-        return res;
-    }
-
-    inline Vector Matrix::getlin(const Index i) const {
-        om_assert(i<nlin());
-        Vector res(ncol());
-    #ifdef HAVE_BLAS
-        const BLAS_INT M = sizet_to_int(nlin());
-        const BLAS_INT N = sizet_to_int(ncol());
-        BLAS(dcopy,DCOPY)(N,data()+i,M,res.data(),1);
-    #else
-        for (Index j=0; j<ncol(); ++j)
-            res(j) = (*this)(i,j);
-    #endif
-        return res;
-    }
-
-    inline void Matrix::setcol(const Index j,const Vector& v) {
-        om_assert(v.size()==nlin() && j<ncol());
-    #ifdef HAVE_BLAS
-        const BLAS_INT M = sizet_to_int(nlin());
-        BLAS(dcopy,DCOPY)(M,v.data(),1,data()+nlin()*j,1);
-    #else
-        for (Index i=0; i<nlin(); ++i)
-            (*this)(i,j) = v(i);
-    #endif
-    }
-
-    inline void Matrix::setlin(const Index i,const Vector& v) {
-        om_assert(v.size()==ncol());
-        om_assert(i<nlin());
-    #ifdef HAVE_BLAS
-        const BLAS_INT M = sizet_to_int(nlin());
-        const BLAS_INT N = sizet_to_int(ncol());
-        BLAS(dcopy,DCOPY)(N,v.data(),1,data()+i,M);
-    #else
-        for (Index j=0; j<ncol(); ++j)
-            (*this)(i,j) = v(j);
-    #endif
     }
 
     inline Vector Matrix::tmult(const Vector& v) const {

--- a/OpenMEEGMaths/include/sparse_matrix.h
+++ b/OpenMEEGMaths/include/sparse_matrix.h
@@ -30,10 +30,10 @@ namespace OpenMEEG {
         typedef Tank::const_iterator                      const_iterator;
         typedef Tank::iterator                            iterator;
 
-        SparseMatrix(): LinOp(0,0,SPARSE,2) {};
-        SparseMatrix(const char* fname): LinOp(0,0,SPARSE,2) { this->load(fname); }
-        SparseMatrix(const size_t N,const size_t M): LinOp(N,M,SPARSE,2) {};
-        ~SparseMatrix() {};
+        SparseMatrix(): LinOp(0,0,SPARSE,2) { }
+        SparseMatrix(const char* fname): LinOp(0,0,SPARSE,2) { load(fname); }
+        SparseMatrix(const size_t N,const size_t M): LinOp(N,M,SPARSE,2) { }
+        ~SparseMatrix() {}
 
         double operator()(const size_t i,const size_t j) const {
             om_assert(i<nlin());
@@ -59,12 +59,7 @@ namespace OpenMEEG {
 
         const Tank& tank() const { return m_tank; }
 
-        void set(const double d) {
-            for (auto& tkelmt : m_tank)
-                tkelmt.second = d;
-        }
-
-        Vector getlin(const size_t i) const {
+        Vector row(const size_t i) const {
             om_assert(i<nlin());
             Vector v(ncol());
             for (size_t j=0; j<ncol(); ++j) {

--- a/OpenMEEGMaths/include/symmatrix.h
+++ b/OpenMEEGMaths/include/symmatrix.h
@@ -33,7 +33,13 @@ namespace OpenMEEG {
         SymMatrix(Dimension M,Dimension N): LinOp(N,N,SYMMETRIC,2),value(size()) { om_assert(N==M); }
         SymMatrix(const SymMatrix& S,const DeepCopy): LinOp(S.nlin(),S.nlin(),SYMMETRIC,2),value(S.size(),S.data()) { }
 
-        explicit SymMatrix(const Vector& v);
+        explicit SymMatrix(const Vector& v) {
+            const size_t sz = v.size();
+            nlin() = std::round((sqrt(1+8*sz)-1)/2);
+            om_assert(size()==sz);
+            value = v.value;
+        }
+
         explicit SymMatrix(const Matrix& A);
 
         size_t size() const { return nlin()*(nlin()+1)/2; };
@@ -46,7 +52,14 @@ namespace OpenMEEG {
         void reference_data(const double* array) { value = LinOpValue(size(),array); }
 
         bool empty() const { return value.empty(); }
-        void set(double x) ;
+
+        SymMatrix& operator=(const double x) {
+            const size_t sz = size();
+            for (size_t i=0; i<sz; ++i)
+                data()[i] = x;
+            return *this;
+        }
+
         double* data() const { return value.get(); }
 
         double  operator()(const Index i,const Index j) const {
@@ -64,25 +77,44 @@ namespace OpenMEEG {
         Matrix    operator()(const Index i_start,const Index i_end,const Index j_start,const Index j_end) const;
         Matrix    submat(const Index istart,const Index isize,const Index jstart,const Index jsize) const;
         SymMatrix submat(const Index istart,const Index iend) const;
-        Vector    getlin(const Index i) const;
-        void      setlin(const Index i,const Vector& v);
+
+        Vector row(const Index i) const {
+            om_assert(i<nlin());
+            Vector v(ncol());
+            for (Index j=0; j<ncol(); ++j)
+                v(j) = (*this)(i,j);
+            return v;
+        }
+
         Vector    solveLin(const Vector& B) const;
         void      solveLin(Vector* B,const int nbvect);
         Matrix    solveLin(Matrix& B) const;
-
-        const SymMatrix& operator=(const double d);
 
         SymMatrix operator+(const SymMatrix& B) const;
         SymMatrix operator-(const SymMatrix& B) const;
         Matrix    operator*(const SymMatrix& B) const;
         Matrix    operator*(const Matrix& B) const;
         Vector    operator*(const Vector& v) const;
-        SymMatrix operator*(const double x) const;
+
+        SymMatrix operator*(const double x) const {
+            SymMatrix res(nlin());
+            const size_t sz = size();
+            for (size_t i=0; i<sz; ++i)
+                res.data()[i] = data()[i]*x;
+            return res;
+        }
+
         SymMatrix operator/(const double x) const { return (*this)*(1/x); }
 
         void operator +=(const SymMatrix& B);
         void operator -=(const SymMatrix& B);
-        void operator *=(const double x);
+
+        void operator *=(const double x) {
+            const size_t sz = size();
+            for (size_t i=0; i<sz; ++i)
+                data()[i] *= x;
+        }
+
         void operator /=(const double x) { (*this)*=(1/x); }
 
         SymMatrix inverse() const;
@@ -313,20 +345,5 @@ namespace OpenMEEG {
         }
     #endif
         return y;
-    }
-
-    inline Vector SymMatrix::getlin(const Index i) const {
-        om_assert(i<nlin());
-        Vector v(ncol());
-        for (Index j=0; j<ncol(); ++j)
-            v(j) = (*this)(i,j);
-        return v;
-    }
-
-    inline void SymMatrix::setlin(const Index i,const Vector& v) {
-        om_assert(v.size()==nlin());
-        om_assert(i<nlin());
-        for (Index j=0; j<ncol(); ++j)
-            (*this)(i,j) = v(j);
     }
 }

--- a/OpenMEEGMaths/include/vector.h
+++ b/OpenMEEGMaths/include/vector.h
@@ -64,12 +64,13 @@ namespace OpenMEEG {
         Vector subvect(const Index istart,const Index isize) const;
 
         Vector operator+(const Vector& v) const;
+
         Vector operator-(const Vector& v) const;
 
         Vector operator-() const {
             // No Blas implementation ?
             Vector res(nlin());
-            for (Index i=0; i<nlin(); i++ )
+            for (Index i=0; i<nlin(); i++)
                 res.data()[i] = -data()[i];
             return res;
         }
@@ -78,23 +79,65 @@ namespace OpenMEEG {
         inline void operator-=(const Vector& v);
         inline void operator*=(const double x);
         void operator/=(const double x) { (*this) *= (1.0/x); }
-        Vector operator+(const double i) const;
-        Vector operator-(const double i) const;
+
+        Vector operator+(const double d) const {
+            Vector p(*this,DEEP_COPY);
+            for (Index i=0; i<nlin(); ++i)
+                p(i) += d;
+            return p;
+        }
+
+        Vector operator-(const double d) const {
+            Vector p(*this,DEEP_COPY);
+            for (Index i=0; i<nlin(); ++i)
+                p(i) -= d;
+            return p;
+        }
+
         inline Vector operator*(const double x) const;
         Vector operator/(const double x) const { return (*this)*(1.0/x); }
         inline double operator*(const Vector& v) const;
+
         Vector operator*(const Matrix& m) const;
 
-        Vector kmult(const Vector& x) const;
+        // Kronecker multiplication
+
+        Vector kmult(const Vector& V) const {
+            om_assert(nlin()==V.nlin());
+            Vector p(nlin());
+            for (Index i=0; i<nlin(); i++ )
+                p(i) = V(i)*(*this)(i);
+            return p;
+        }
+
         // Vector conv(const Vector& v) const;
         // Vector conv_trunc(const Vector& v) const;
+
         Matrix outer_product(const Vector& v) const;
 
-        double norm() const;
-        double sum() const;
+        double norm() const {
+        #ifdef HAVE_BLAS
+            return BLAS(dnrm2,DNRM2)(sizet_to_int(nlin()),data(),1);
+        #else
+            throw OpenMEEG::maths::LinearAlgebraError("'Vector::norm' not implemented, requires BLAS");
+        #endif
+        }
+
+        double sum() const {
+            double s=0;
+            for (Index i=0; i<nlin(); ++i)
+                s += (*this)(i);
+            return s;
+        }
+
         double mean() const { return sum()/size(); }
 
-        void set(const double x);
+        Vector& operator=(const double x) {
+            om_assert(nlin()>0);
+            for (Index i=0; i<nlin(); ++i)
+                (*this)(i) = x;
+            return *this;
+        }
 
         void save(const char *filename) const;
         void load(const char *filename);
@@ -198,20 +241,12 @@ namespace OpenMEEG {
     #endif
     }
 
-    inline double Vector::norm() const {
-    #ifdef HAVE_BLAS
-        return BLAS(dnrm2,DNRM2)(sizet_to_int(nlin()),data(),1);
-    #else
-        throw OpenMEEG::maths::LinearAlgebraError("'Vector::norm' not implemented, requires BLAS");
-    #endif
-    }
-
     // inline Vector Vector::conv(const Vector& v) const {
     //     if (v.nlin()<nlin())
     //         return v.conv(*this);
     //
     //     Vector p(nlin()+v.nlin()-1);
-    //     p.set(0);
+    //     p = 0.0;
     //     for (Index i=0; i<v.nlin(); ++i) {
     // #ifdef HAVE_BLAS
     //         BLAS(daxpy,DAXPY)(sizet_to_int(nlin()),v(i),data(),1,p.data()+i,1);
@@ -225,7 +260,7 @@ namespace OpenMEEG {
     //
     // inline Vector Vector::conv_trunc(const Vector& v) const {
     //     Vector p(v.nlin());
-    //     p.set(0);
+    //     p = 0.0;
     //     for (Index i=0; i<v.nlin(); ++i)
     //     {
     //         const Index m = std::min(nlin(),v.nlin()-i);

--- a/OpenMEEGMaths/src/matrix.cpp
+++ b/OpenMEEGMaths/src/matrix.cpp
@@ -17,13 +17,6 @@
 
 namespace OpenMEEG {
 
-    const Matrix& Matrix::set(const double d) {
-        const size_t sz = size();
-        for (size_t i=0; i<sz; i++)
-            data()[i] = d;
-        return *this;
-    }
-
     Matrix::Matrix(const SymMatrix& A): LinOp(A.nlin(),A.ncol(),FULL,2),value(size()) {
         for (Index j=0; j<ncol(); ++j)
             for (Index i=0; i<nlin(); ++i)
@@ -31,7 +24,7 @@ namespace OpenMEEG {
     }
 
     Matrix::Matrix(const SparseMatrix& A): LinOp(A.nlin(),A.ncol(),FULL,2),value(size()) {
-        set(0.0);
+        *this = 0.0;
         for (SparseMatrix::const_iterator it=A.begin(); it!=A.end(); ++it)
             (*this)(it->first.first,it->first.second) = it->second;
     }
@@ -62,12 +55,12 @@ namespace OpenMEEG {
 
         if (rank==0) {
             Matrix result(ncol(),nlin());
-            result.set(0.0);
+            result = 0.0;
             return result;
         }
 
         Matrix D(rank,rank);
-        D.set(0.0);
+        D = 0.0;
         for (Index i=0; i<rank; ++i)
             D(i,i) = 1.0/S(i,i);
 
@@ -94,10 +87,10 @@ namespace OpenMEEG {
         const Index mini = std::min(nlin(),ncol());
         const Index maxi = std::max(nlin(),ncol());
         U = Matrix(nlin(),nlin());
-        U.set(0.0);
+        U = 0.0;
         S = SparseMatrix(nlin(),ncol());
         V = Matrix(ncol(),ncol());
-        V.set(0.0);
+        V = 0.0;
         double* s = new double[mini];
         // int lwork = 4 *mini*mini + maxi + 9*mini;
         // http://www.netlib.no/netlib/lapack/double/dgesdd.f :
@@ -128,7 +121,7 @@ namespace OpenMEEG {
     Matrix Matrix::operator*(const SparseMatrix& mat) const {
         om_assert(ncol()==mat.nlin());
         Matrix out(nlin(),mat.ncol());
-        out.set(0.0);
+        out = 0.0;
 
         for (SparseMatrix::const_iterator it=mat.begin(); it!=mat.end(); ++it) {
             const Index i = it->first.first;

--- a/OpenMEEGMaths/src/sparse_matrix.cpp
+++ b/OpenMEEGMaths/src/sparse_matrix.cpp
@@ -21,7 +21,7 @@ namespace OpenMEEG {
 
     Vector SparseMatrix::operator*(const Vector& x) const {
         Vector ret(nlin());
-        ret.set(0);
+        ret = 0.0;
 
         for (const auto& tkelmt : m_tank) {
             const size_t i = tkelmt.first.first;
@@ -37,7 +37,7 @@ namespace OpenMEEG {
     {
         om_assert(ncol()==mat.nlin());
         Matrix out(nlin(),mat.ncol());
-        out.set(0.0);
+        out = 0.0;
 
         for (const auto& tkelmt : m_tank) {
             const size_t i = tkelmt.first.first;
@@ -53,7 +53,7 @@ namespace OpenMEEG {
     Matrix SparseMatrix::operator*(const Matrix& mat) const {
         om_assert(ncol()==mat.nlin());
         Matrix out(nlin(),mat.ncol());
-        out.set(0.0);
+        out = 0.0;
 
         for (const auto& tkelmt : m_tank) {
             const size_t i = tkelmt.first.first;

--- a/OpenMEEGMaths/src/symmatrix.cpp
+++ b/OpenMEEGMaths/src/symmatrix.cpp
@@ -16,45 +16,12 @@
 
 namespace OpenMEEG {
 
-    const SymMatrix& SymMatrix::operator=(const double d) {
-        const size_t sz = size();
-        for (size_t i=0; i<sz; ++i)
-            data()[i] = d;
-        return *this;
-    }
-
-    SymMatrix::SymMatrix(const Vector& v) {
-        const size_t sz = v.size();
-        nlin() = std::round((sqrt(1+8*sz)-1)/2);
-        om_assert(size()==sz);
-        value = v.value;
-    }
 
     SymMatrix::SymMatrix(const Matrix& M): LinOp(M.nlin(),M.nlin(),SYMMETRIC,2),value(size()) {
         om_assert(nlin()==M.nlin());
         for (Index i=0; i<nlin(); ++i)
             for (Index j=i; j<nlin(); ++j)
                 (*this)(i,j) = M(i,j);
-    }
-
-    void SymMatrix::set(const double x) {
-        const size_t sz = size();
-        for (size_t i=0; i<sz; ++i)
-            data()[i] = x;
-    }
-
-    SymMatrix SymMatrix::operator*(const double x) const {
-        SymMatrix C(nlin());
-        const size_t sz = size();
-        for (size_t i=0; i<sz; ++i)
-            C.data()[i] = data()[i]*x;
-        return C;
-    }
-
-    void SymMatrix::operator*=(const double x) {
-        const size_t sz = size();
-        for (size_t i=0; i<sz; ++i)
-            data()[i] *= x;
     }
 
     Matrix SymMatrix::operator()(const Index i_start,const Index i_end,const Index j_start,const Index j_end) const {

--- a/OpenMEEGMaths/src/vector.cpp
+++ b/OpenMEEGMaths/src/vector.cpp
@@ -23,45 +23,13 @@ namespace OpenMEEG {
         value  = A.value;
     }
 
-    Vector Vector::kmult(const Vector& v) const { // Kronecker multiplication
-        om_assert(nlin()==v.nlin());
-        Vector p(nlin());
-        for (Index i=0; i<nlin(); i++ )
-            p(i) = v(i)*(*this)(i);
-        return p;
-    }
-
-    Vector Vector::operator+(const double x) const {
-        Vector p(*this,DEEP_COPY);
-        for (Index i=0; i<nlin(); ++i)
-            p(i) += x;
-        return p;
-    }
-
-    Vector Vector::operator-(double x) const {
-        Vector p(*this,DEEP_COPY);
-        for (Index i=0; i<nlin(); ++i)
-            p(i) -= x;
-        return p;
-    }
-
     Vector Vector::operator*(const Matrix& m) const {
         om_assert(nlin()==m.nlin());
-        Vector c(m.ncol());
-        return m.transpose()*(*this);
-    }
-
-    void Vector::set(const double x) {
-        om_assert(nlin()>0);
-        for (Index i=0; i<nlin(); ++i)
-            (*this)(i) = x;
-    }
-
-    double Vector::sum() const {
-        double s=0;
-        for (Index i=0; i<nlin(); ++i)
-            s += (*this)(i);
-        return s;
+        Vector res(m.ncol());
+        for (Index i=0; i<m.nlin(); ++i)
+            for (Index j=0; j<m.ncol(); ++j)
+                res(i) += m(i,j)*(*this)(i);
+        return res;
     }
 
     void Vector::info() const {
@@ -136,7 +104,7 @@ namespace OpenMEEG {
     {
         om_assert(size()==v.size());
         Matrix A(size(),v.size());
-        A.set(0.0);
+        A = 0.0;
     #ifdef HAVE_BLAS
         const BLAS_INT sz = sizet_to_int(size());
         DGER(sz,sz,1.0,data(),1,v.data(),1,A.data(),sz);

--- a/OpenMEEGMaths/tests/full.cpp
+++ b/OpenMEEGMaths/tests/full.cpp
@@ -73,7 +73,8 @@ int main () {
     M.info();
 
     // SVD (wikipedia example)
-    M1 = Matrix(4,5); M1.set(0.0);
+    M1 = Matrix(4,5);
+    M1 = 0.0;
     M1(0,0) = 1; M1(0,4) = 2;
     M1(1,2) = 3; M1(3,1) = 4;
 
@@ -96,11 +97,12 @@ int main () {
     }
 
     // PseudoInverse
-    M1.set(0.0);
+
+    M1 = 0.0;
     M1(0,0) = 1; M1(0,4) = 2;
     M1(1,2) = 3; M1(3,1) = 4;
     Matrix M1pinv = M1.pinverse();
-    zero.set(0.);
+    zero = 0.0;
     zero = M1*M1pinv*M1-M1;
     if (zero.frobenius_norm()>eps) {
         std::cout << "pinverse = M^{+} = " << std::endl;

--- a/OpenMEEGMaths/tests/generic_test.hpp
+++ b/OpenMEEGMaths/tests/generic_test.hpp
@@ -20,7 +20,7 @@ void genericTest(const std::string& basename,T &M) {
     std::cout << "   nlin  = " << static_cast<int>(M.nlin()) << std::endl;
     std::cout << "   ncol  = " << static_cast<int>(M.ncol()) << std::endl;
     Vector v(M.ncol());
-    v.set(1);
+    v = 1.0;
     v = M*v;
 
     std::cout << std::endl << "BASE :" << std::endl;

--- a/OpenMEEGMaths/tests/sparse.cpp
+++ b/OpenMEEGMaths/tests/sparse.cpp
@@ -30,12 +30,12 @@ int main () {
     genericTest("sparse",spM);
 
     Matrix U(10,10);
-    U.set(1.0);
+    U = 1.0;
     U(2,3)=0.12;
     U(1,9)=12.01;
     U(4,8)=-2.1;
     Vector v(10);
-    v.set(2.);
+    v = 2.0;
     v(3)=v(8)=0.11;
     // Mat & Sparse
     Matrix Mzero = spM*U - Matrix(spM)*U - Matrix(spM)*U + spM*U;

--- a/OpenMEEGMaths/tests/vector.cpp
+++ b/OpenMEEGMaths/tests/vector.cpp
@@ -21,7 +21,7 @@ int main () {
     std::cout << std::endl << "========== vectors ==========" << std::endl;
 
     Vector v(8);
-    v.set(0);
+    v= 0.0;
     v.save("tmp.bin");
 
     for (int i=0;i<8;++i)

--- a/apps/tools/mesh_convert.cpp
+++ b/apps/tools/mesh_convert.cpp
@@ -73,10 +73,14 @@ main(int argc,char* argv[]) {
         for (const auto& vertex : m.vertices()) {
             Vertex& v = *vertex;
             Vector point(4);
-            point.set(1.0);
-            point(0) = v(0); point(1) = v(1); point(2) = v(2);
+            point(0) = v(0);
+            point(1) = v(1);
+            point(2) = v(2);
+            point(3) = 1.0;
             Vector out_point = mat*point;
-            v(0) = out_point(0); v(1) = out_point(1); v(2) = out_point(2);
+            v(0) = out_point(0);
+            v(1) = out_point(1);
+            v(2) = out_point(2);
         }
     }
 

--- a/apps/tools/register_squids.cpp
+++ b/apps/tools/register_squids.cpp
@@ -60,9 +60,9 @@ main(int argc,char* argv[]) {
         (fiducials.ncol()!=3))
         throw std::invalid_argument("OpenMEEG only handles 3 3D fiducial points.");
 
-    const Vector nas = fiducials.getlin(0); // Nasion
-    const Vector lpa = fiducials.getlin(1); // Left preauricular
-    const Vector rpa = fiducials.getlin(2); // Right preauricular
+    const Vector nas = fiducials.row(0); // Nasion
+    const Vector lpa = fiducials.row(1); // Left preauricular
+    const Vector rpa = fiducials.row(2); // Right preauricular
 
     const Vector origin = (lpa+rpa)/2.0;
     Vector vx = (nas-origin);
@@ -74,9 +74,9 @@ main(int argc,char* argv[]) {
     vz = vz/vz.norm();
 
     Matrix R(3,3);
-    R.setlin(0,vx);
-    R.setlin(1,vy);
-    R.setlin(2,vz);
+    R.row(0) = vx;
+    R.row(1) = vy;
+    R.row(2) = vz;
 
     const Vector& T = -(R*origin);
 

--- a/tests/test_compare_matrix.cpp
+++ b/tests/test_compare_matrix.cpp
@@ -329,8 +329,8 @@ bool compare_rdm(const T& mat1,const T& mat2,const double eps,const size_t col){
 
     std::cout.precision(20); // TODO
     for (unsigned j=jmin; j<jmax; ++j) {
-        Vector col1 = mat1.getcol(j);
-        Vector col2 = mat2.getcol(j);
+        Vector col1 = mat1.column(j);
+        Vector col2 = mat2.column(j);
         col1 = col1-col1.mean();
         col2 = col2-col2.mean();
         col1 = col1/col1.norm();
@@ -371,8 +371,8 @@ bool compare_mag(const T& mat1,const T& mat2,const double eps,const size_t col){
     }
 
     for (unsigned j=jmin; j<jmax; ++j) {
-        Vector col1 = mat1.getcol(j);
-        Vector col2 = mat2.getcol(j);
+        Vector col1 = mat1.column(j);
+        Vector col2 = mat2.column(j);
         col1 = col1-col1.mean();
         col2 = col2-col2.mean();
         const double MAG    = col1.norm()/col2.norm();

--- a/tests/test_validationEIT.cpp
+++ b/tests/test_validationEIT.cpp
@@ -36,7 +36,7 @@ Vector
 VR(const Geometry& geo,const Matrix& points,const SymMatrix& HeadMatInv,const Matrix& rhsEIT) {
     const Matrix& matdx         = Surf2VolMat(geo,points);
     const Matrix& EEGGainMatrix = matdx*HeadMatInv;
-    return (EEGGainMatrix*rhsEIT).getcol(0);
+    return (EEGGainMatrix*rhsEIT).column(0);
 }
 
 int
@@ -105,11 +105,11 @@ main(const int argc,const char* argv[]) {
 
     // Potential at the electrodes positions
 
-    const Vector& VRi = (matH2E*PotExt).getlin(0);
-    const Vector& VRe = (matH2E*PotExt).getlin(1);
+    const Vector& VRi = (matH2E*PotExt).row(0);
+    const Vector& VRe = (matH2E*PotExt).row(1);
 
     Matrix diffVf(1,ndip);
-    diffVf.setlin(0,VRi-VRe);
+    diffVf.row(0) = VRi-VRe;
     diffVf.save(argv[7]);
 
     constexpr double dirac = 1.0; // The injection current
@@ -128,10 +128,10 @@ main(const int argc,const char* argv[]) {
     constexpr double delta = 1e-6;
     Matrix gradVj(ndip,3);
     for (unsigned i=0; i<3; ++i) {
-        points.setcol(i,points.getcol(i)+delta);
+        points.column(i) += delta;
         const Vector& VRd = VR(geo,points,HeadMatInv,rhsEIT);
-        gradVj.setcol(i,(VRd-VR0)/delta);
-        points.setcol(i,dipoles.getcol(i));
+        gradVj.column(i) = (VRd-VR0)/delta;
+        points.column(i) = dipoles.column(i);
     }
 
     Matrix qgradVj(1,ndip);

--- a/wrapping/python/openmeeg/_openmeeg.i
+++ b/wrapping/python/openmeeg/_openmeeg.i
@@ -581,6 +581,8 @@ namespace OpenMEEG {
 
     // Setters
 
+    void set(const double d) { (*($self)) = d; }
+
     void setvalue(const unsigned i,const double d) { (*($self))(i) = d; }
 
     double value(unsigned i) {
@@ -589,6 +591,9 @@ namespace OpenMEEG {
         return (*($self))(i);
     }
 }
+
+%ignore Matrix::row(const Index);
+%ignore Matrix::column(const Index);
 
 %extend OpenMEEG::Matrix {
 
@@ -625,6 +630,11 @@ namespace OpenMEEG {
         return PyArray_Return(array);
     }
 
+    void set(const double d) { (*($self)) = d; }
+
+    void setlin(const unsigned i,const Vector& V) { (*($self)).row(i) = V;    }
+    void setcol(const unsigned i,const Vector& V) { (*($self)).column(i) = V; }
+
     void setvalue(const unsigned i,const unsigned j,const double d) { (*($self))(i,j) = d; }
 
     double value(const unsigned i,const unsigned j) {
@@ -635,6 +645,7 @@ namespace OpenMEEG {
 }
 
 %extend OpenMEEG::SymMatrix {
+
     SymMatrix(PyObject* pyobj) { return new_OpenMEEG_SymMatrix(pyobj); }
 
     PyObject* array_flat() {


### PR DESCRIPTION
This changes a bit several matrix/vector interfaces to promote a more natural notation (operators =, +=), having operators returning their results (instead of modifying a vector passed as a parameter), etc 
The python interface remains unchanged by add extension with the old names (set, setlin, setcol). I have not implemented the getlin and getcol interfaces as they do not seem to be used (and are provided by the methods row and column).